### PR TITLE
✨ [feat] #23 주문 삭제 API 구현

### DIFF
--- a/src/main/java/org/example/oshipserver/domain/order/controller/OrderController.java
+++ b/src/main/java/org/example/oshipserver/domain/order/controller/OrderController.java
@@ -3,9 +3,14 @@ package org.example.oshipserver.domain.order.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.oshipserver.domain.order.dto.request.OrderCreateRequest;
+import org.example.oshipserver.domain.order.dto.request.OrderDeleteRequest;
 import org.example.oshipserver.domain.order.dto.response.OrderCreateResponse;
 import org.example.oshipserver.domain.order.service.OrderService;
 import org.example.oshipserver.global.common.response.BaseResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,11 +24,25 @@ public class OrderController {
     private final OrderService orderService;
 
     @PostMapping
-    public BaseResponse<OrderCreateResponse> createOrder(@Valid @RequestBody OrderCreateRequest orderCreateRequest) {
+    public ResponseEntity<BaseResponse<OrderCreateResponse>> createOrder(
+        @Valid @RequestBody OrderCreateRequest orderCreateRequest
+    ) {
         String masterNo = orderService.createOrder(orderCreateRequest);
-        return new BaseResponse<>(201, "주문 생성이 완료되었습니다.", new OrderCreateResponse(masterNo));
+        BaseResponse<OrderCreateResponse> response =
+            new BaseResponse<>(201, "주문 생성이 완료되었습니다.", new OrderCreateResponse(masterNo));
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-
+    /**
+     * 주문 삭제 (Soft Delete)
+     */
+    @DeleteMapping("/{id}")
+    public BaseResponse<Void> deleteOrder(@PathVariable final Long id,
+        @Valid @RequestBody final OrderDeleteRequest request
+    ) {
+        orderService.softDeleteOrder(id, request.deletedBy());
+        return new BaseResponse<>(204, "주문이 성공적으로 삭제되었습니다.", null);
+    }
 
 }

--- a/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderDeleteRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderDeleteRequest.java
@@ -1,0 +1,9 @@
+package org.example.oshipserver.domain.order.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import org.example.oshipserver.domain.order.entity.enums.DeleterRole;
+
+public record OrderDeleteRequest(
+    @NotNull(message = "삭제 주체는 필수입니다.")
+    DeleterRole deletedBy
+) {}

--- a/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
@@ -19,6 +19,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.oshipserver.domain.order.dto.request.OrderCreateRequest;
+import org.example.oshipserver.domain.order.entity.enums.DeleterRole;
 import org.example.oshipserver.domain.order.entity.enums.OrderStatus;
 import org.example.oshipserver.global.entity.BaseTimeEntity;
 
@@ -50,7 +51,18 @@ public class Order extends BaseTimeEntity {
     private LocalDateTime deletedAt;
 
     // 상태
-    private Boolean isDeleted;
+    private boolean deleted = false;
+
+
+    @Enumerated(EnumType.STRING)
+    private DeleterRole deletedBy;
+
+    public void softDelete(DeleterRole deletedBy) {
+        this.deleted = true;
+        this.deletedBy = deletedBy;
+        this.deletedAt = LocalDateTime.now();
+    }
+
 
     @Enumerated(EnumType.STRING)
     private OrderStatus currentStatus;
@@ -91,7 +103,6 @@ public class Order extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "seller_id", nullable = false)
     private Seller seller;
-
     */
 
     @OneToOne(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -113,7 +124,7 @@ public class Order extends BaseTimeEntity {
         BigDecimal dimensionHeight,
         BigDecimal dimensionLength,
         LocalDateTime orderedAt,
-        Boolean isDeleted,
+        Boolean deleted,
         OrderStatus currentStatus
     ) {
         this.orderNo = orderNo;
@@ -126,8 +137,11 @@ public class Order extends BaseTimeEntity {
         this.dimensionHeight = dimensionHeight;
         this.dimensionLength = dimensionLength;
         this.orderedAt = orderedAt;
-        this.isDeleted = isDeleted;
         this.currentStatus = currentStatus;
+        // Soft delete 관련 초기값
+        this.deleted = false;
+        this.deletedBy = null;
+        this.deletedAt = null;
     }
 
 
@@ -148,7 +162,7 @@ public class Order extends BaseTimeEntity {
             .dimensionHeight(BigDecimal.valueOf(dto.dimensionHeight()))
             .dimensionLength(BigDecimal.valueOf(dto.dimensionLength()))
             .orderedAt(LocalDateTime.now())
-            .isDeleted(false)
+            .deleted(false)
             .currentStatus(OrderStatus.PENDING)
             .build();
     }

--- a/src/main/java/org/example/oshipserver/domain/order/entity/enums/DeleterRole.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/enums/DeleterRole.java
@@ -1,0 +1,5 @@
+package org.example.oshipserver.domain.order.entity.enums;
+
+public enum DeleterRole {
+    ADMIN, SELLER
+}

--- a/src/main/java/org/example/oshipserver/domain/order/service/OrderService.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/OrderService.java
@@ -13,10 +13,12 @@ import org.example.oshipserver.domain.order.entity.OrderSender;
 import org.example.oshipserver.domain.order.entity.RecipientAddress;
 import org.example.oshipserver.domain.order.entity.SenderAddress;
 import org.example.oshipserver.domain.order.entity.enums.CountryCode;
+import org.example.oshipserver.domain.order.entity.enums.DeleterRole;
 import org.example.oshipserver.domain.order.repository.OrderRepository;
 import org.example.oshipserver.global.exception.ApiException;
 import org.example.oshipserver.global.exception.ErrorType;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -119,6 +121,20 @@ public class OrderService {
         int randomNumber = 1000000 + new Random().nextInt(9000000);
         return prefix + date + country + randomNumber;
     }
+
+    @Transactional
+    public void softDeleteOrder(Long orderId, DeleterRole deletedBy) {
+        Order order = orderRepository.findById(orderId)
+            .orElseThrow(() -> new ApiException("주문을 찾을 수 없습니다.", ErrorType.NOT_FOUND));
+
+        if (order.isDeleted()) {
+            throw new ApiException("이미 삭제된 주문입니다.", ErrorType.DB_FAIL);
+        }
+
+        order.softDelete(deletedBy);
+    }
+
+
 
 }
 


### PR DESCRIPTION
## ✏️ Issue
Closes #23 

## ☑️ Todo
- 주문 삭제(Soft Delete) API 구현  
- 삭제 요청 시 다음과 같은 예외 처리 추가  
  - 존재하지 않는 주문  
  - 이미 삭제된 주문  

## 🧾Details
 주문(Order) 도메인의 Soft Delete 방식 적용

Hibernate의 자동 필터(`@SQLRestriction`) 대신, 명시적인 soft delete 방식(`deleted`, `deletedAt`, `deletedBy`)을 도입했습니다.
- [ ]  삭제 주체(ADMIN, SELLER)를 명확하게 기록할 수 있어야 함
- [ ]  삭제 여부에 따라 도메인 로직에서 유연하게 분기 처리 가능해야 함

따라서 Order 도메인에는 명시적 soft delete 방식이 더 적합하다고 판단하였습니다.

## ✅ Test Result
![image](https://github.com/user-attachments/assets/40d78746-d1b9-4df6-903b-2de55a0f2cfc)


## 💌 Reviewer Notes
DeleterRole enum 구조에 대한 의견 부탁드립니다.
Soft Delete 방식에 대한 도메인 처리 로직이나 정책에 개선점이 있다면 피드백 주세요 🙏