### PR TITLE
♻️ [refactor] #33 UUID 기반 Master No 생성 방식으로 개선

### DIFF
--- a/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
@@ -58,7 +58,6 @@ public class Order extends BaseTimeEntity {
     private BigDecimal dimensionLength;
 
     // 시간 정보
-    private LocalDateTime orderedAt;
     private LocalDateTime deletedAt;
 
     // 상태
@@ -91,9 +90,6 @@ public class Order extends BaseTimeEntity {
     private Boolean isPrintBarcode;
     private Boolean isPrintAwb;
 
-    // 운송장 출력 시각
-    private LocalDateTime awbPrintedAt;
-
     // 배송 완료 시각 (트래킹 기준)
     private LocalDateTime deliveredAt;
 
@@ -125,7 +121,6 @@ public class Order extends BaseTimeEntity {
         BigDecimal dimensionWidth,
         BigDecimal dimensionHeight,
         BigDecimal dimensionLength,
-        LocalDateTime orderedAt,
         boolean deleted,
         OrderStatus currentStatus,
         String itemContentsType,
@@ -143,7 +138,6 @@ public class Order extends BaseTimeEntity {
         this.dimensionWidth = dimensionWidth;
         this.dimensionHeight = dimensionHeight;
         this.dimensionLength = dimensionLength;
-        this.orderedAt = orderedAt;
         this.currentStatus = currentStatus;
         this.itemContentsType = itemContentsType;
         this.serviceType = serviceType;
@@ -171,7 +165,6 @@ public class Order extends BaseTimeEntity {
             .dimensionWidth(BigDecimal.valueOf(dto.dimensionWidth()))
             .dimensionHeight(BigDecimal.valueOf(dto.dimensionHeight()))
             .dimensionLength(BigDecimal.valueOf(dto.dimensionLength()))
-            .orderedAt(LocalDateTime.now())
             .deleted(false)
             .currentStatus(OrderStatus.PENDING)
             .itemContentsType(dto.itemContentsType())


### PR DESCRIPTION
## ✏️ Issue

Closes #33 

## ☑️ Todo

- 주문 Master No 생성 방식 변경
- 중복 체크 로직 제거 및 UUID 기반 생성 방식 적용

## ✅ Test Result

- 새로운 Master No 형식 (`OSH250604US550E840`)으로 정상 생성 확인
- 기존 중복 회피용 retry 로직 제거
- 주문 생성 흐름 정상 동작 확인

## 💌 Reviewer Notes

- 기존에는 Master No의 중복을 피하기 위해 난수 + 중복 조회 방식(`generateUniqueMasterNo`)을 사용했습니다.
- 이번 PR에서는 **UUID 기반 난수 세그먼트**를 도입하여 **충돌 확률을 실질적으로 제거**하고, 생성 과정을 단순화했습니다.
- Master No의 포맷이 `OSH + 날짜(yyMMdd) + 국가코드 + UUID 앞 7자리`로 변경되어, 주문 위키의 관련 문서도 함께 업데이트되어야 합니다.