### PR TITLE
✨ [feat] #37 주문 목록조회, 상세조회 API 구현

### DIFF
--- a/src/main/java/org/example/oshipserver/domain/order/controller/OrderController.java
+++ b/src/main/java/org/example/oshipserver/domain/order/controller/OrderController.java
@@ -5,16 +5,22 @@ import lombok.RequiredArgsConstructor;
 import org.example.oshipserver.domain.order.dto.request.OrderCreateRequest;
 import org.example.oshipserver.domain.order.dto.request.OrderUpdateRequest;
 import org.example.oshipserver.domain.order.dto.response.OrderCreateResponse;
+import org.example.oshipserver.domain.order.dto.response.OrderDetailResponse;
+import org.example.oshipserver.domain.order.dto.response.OrderListResponse;
 import org.example.oshipserver.domain.order.service.OrderService;
 import org.example.oshipserver.global.common.response.BaseResponse;
+import org.example.oshipserver.global.common.response.PageResponseDto;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -35,6 +41,22 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    @GetMapping
+    public BaseResponse<PageResponseDto<OrderListResponse>> getOrderList(
+        @RequestParam(required = false) Long sellerId,
+        @RequestParam(required = false) String startDate,
+        @RequestParam(required = false) String endDate,
+        Pageable pageable
+    ) {
+        PageResponseDto<OrderListResponse> response = orderService.getOrderList(sellerId, startDate, endDate, pageable);
+        return new BaseResponse<>(200, "주문 목록 조회 성공", response);
+    }
+
+
+    @GetMapping("/{id}")
+    public BaseResponse<OrderDetailResponse> getOrderDetail(@PathVariable final Long id) {
+        return new BaseResponse<>(200, "주문 상세 조회 성공", orderService.getOrderDetail(id));
+    }
 
     @PatchMapping("/{id}")
     public ResponseEntity<BaseResponse<Void>> updateOrder(

--- a/src/main/java/org/example/oshipserver/domain/order/dto/response/OrderDetailResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/response/OrderDetailResponse.java
@@ -1,0 +1,145 @@
+package org.example.oshipserver.domain.order.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.example.oshipserver.domain.order.entity.Order;
+
+public record OrderDetailResponse(
+    Long id,
+    String orderNo,
+    String storePlatform,
+    String storeName,
+    String shipmentStatus,
+    String orderStatus,
+    LocalDateTime createdAt,
+    int parcelCount,
+    BigDecimal shipmentActualWeight,
+    BigDecimal shipmentVolumeWeight,
+    String weightUnit,
+    String shippingTerm,
+    boolean isPrintBarcode,
+    boolean isPrintAwb,
+    Integer deliveryDays,
+    String oshipMasterNo,
+    Dimension dimension,
+    Sender sender,
+    Recipient recipient,
+    List<Item> items
+) {
+
+    public record Dimension(
+        BigDecimal width,
+        BigDecimal length,
+        BigDecimal height
+    ) {}
+
+    public record Sender(
+        String name,
+        String company,
+        String email,
+        String phoneNo,
+        Address address
+    ) {}
+
+    public record Recipient(
+        String name,
+        String company,
+        String email,
+        String phoneNo,
+        String taxId,
+        Address address
+    ) {}
+
+    public record Address(
+        String countryCode,
+        String state,
+        String stateCode,
+        String city,
+        String address1,
+        String address2,
+        String zipCode
+    ) {}
+
+    public record Item(
+        Long id,
+        String name,
+        int quantity,
+        BigDecimal unitValue,
+        String valueCurrency,
+        BigDecimal weight,
+        String weightUnit,
+        String itemHsCode,
+        String itemOriginCountryCode
+    ) {}
+
+    public static OrderDetailResponse from(Order order) {
+        return new OrderDetailResponse(
+            order.getId(),
+            order.getOrderNo(),
+            order.getSender().getStorePlatform(),
+            order.getSender().getStoreName(),
+            order.getLastTrackingEvent(),
+            order.getCurrentStatus().name(),
+            order.getCreatedAt(),
+            order.getParcelCount(),
+            order.getShipmentActualWeight(),
+            order.getShipmentVolumeWeight(),
+            order.getWeightUnit(),
+            order.getShippingTerm(),
+            Boolean.TRUE.equals(order.getIsPrintBarcode()),
+            Boolean.TRUE.equals(order.getIsPrintAwb()),
+            order.getDeliveryDays(),
+            order.getOshipMasterNo(),
+            new Dimension(
+                order.getDimensionWidth(),
+                order.getDimensionLength(),
+                order.getDimensionHeight()
+            ),
+            new Sender(
+                order.getSender().getSenderName(),
+                order.getSender().getSenderCompany(),
+                order.getSender().getSenderEmail(),
+                order.getSender().getSenderPhoneNo(),
+                new Address(
+                    order.getSender().getSenderAddress().getSenderCountryCode().name(),
+                    order.getSender().getSenderAddress().getSenderState(),
+                    order.getSender().getSenderAddress().getSenderStateCode().name(),
+                    order.getSender().getSenderAddress().getSenderCity(),
+                    order.getSender().getSenderAddress().getSenderAddress1(),
+                    order.getSender().getSenderAddress().getSenderAddress2(),
+                    order.getSender().getSenderAddress().getSenderZipCode()
+                )
+            ),
+            new Recipient(
+                order.getRecipient().getRecipientName(),
+                order.getRecipient().getRecipientCompany(),
+                order.getRecipient().getRecipientEmail(),
+                order.getRecipient().getRecipientPhoneNo(),
+                order.getRecipient().getRecipientAddress().getRecipientTaxId(),
+                new Address(
+                    order.getRecipient().getRecipientAddress().getRecipientCountryCode().name(),
+                    order.getRecipient().getRecipientAddress().getRecipientState(),
+                    order.getRecipient().getRecipientAddress().getRecipientStateCode().name(),
+                    order.getRecipient().getRecipientAddress().getRecipientCity(),
+                    order.getRecipient().getRecipientAddress().getRecipientAddress1(),
+                    order.getRecipient().getRecipientAddress().getRecipientAddress2(),
+                    order.getRecipient().getRecipientAddress().getRecipientZipCode()
+                )
+            ),
+            order.getOrderItems().stream()
+                .map(item -> new Item(
+                    item.getId(),
+                    item.getName(),
+                    item.getQuantity(),
+                    item.getUnitValue(),
+                    item.getValueCurrency(),
+                    item.getWeight(),
+                    item.getWeightUnit(),
+                    item.getHsCode(),
+                    item.getOriginCountryCode()
+                ))
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/order/dto/response/OrderListResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/response/OrderListResponse.java
@@ -1,0 +1,45 @@
+package org.example.oshipserver.domain.order.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.example.oshipserver.domain.order.entity.Order;
+
+public record OrderListResponse(
+    Long id,
+    String orderNo,
+    String oshopMasterNo,
+    String storePlatform,
+    String storeName,
+    LocalDateTime createdAt,
+    int parcelCount,
+    BigDecimal shipmentActualWeight,
+    BigDecimal shipmentVolumeWeight,
+    String senderName,
+    String recipientName,
+    Integer deliveryDays,
+    String lastTrackingEvent,
+    String orderStatus,
+    boolean isPrintBarcode,
+    boolean isPrintAwb
+) {
+    public static OrderListResponse from(Order order) {
+        return new OrderListResponse(
+            order.getId(),
+            order.getOrderNo(),
+            order.getOshipMasterNo(),
+            order.getSender() != null ? order.getSender().getStorePlatform() : null,
+            order.getSender() != null ? order.getSender().getStoreName() : null,
+            order.getCreatedAt(),
+            order.getParcelCount(),
+            order.getShipmentActualWeight(),
+            order.getShipmentVolumeWeight(),
+            order.getSender() != null ? order.getSender().getSenderName() : null,
+            order.getRecipient() != null ? order.getRecipient().getRecipientName() : null,
+            order.getDeliveryDays(),
+            order.getLastTrackingEvent(),
+            order.getCurrentStatus() != null ? order.getCurrentStatus().name() : null,
+            Boolean.TRUE.equals(order.getIsPrintBarcode()),
+            Boolean.TRUE.equals(order.getIsPrintAwb())
+        );
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
@@ -58,7 +58,6 @@ public class Order extends BaseTimeEntity {
     private BigDecimal dimensionLength;
 
     // 시간 정보
-    private LocalDateTime orderedAt;
     private LocalDateTime deletedAt;
 
     // 상태
@@ -91,9 +90,6 @@ public class Order extends BaseTimeEntity {
     private Boolean isPrintBarcode;
     private Boolean isPrintAwb;
 
-    // 운송장 출력 시각
-    private LocalDateTime awbPrintedAt;
-
     // 배송 완료 시각 (트래킹 기준)
     private LocalDateTime deliveredAt;
 
@@ -125,7 +121,6 @@ public class Order extends BaseTimeEntity {
         BigDecimal dimensionWidth,
         BigDecimal dimensionHeight,
         BigDecimal dimensionLength,
-        LocalDateTime orderedAt,
         boolean deleted,
         OrderStatus currentStatus,
         String itemContentsType,
@@ -143,7 +138,6 @@ public class Order extends BaseTimeEntity {
         this.dimensionWidth = dimensionWidth;
         this.dimensionHeight = dimensionHeight;
         this.dimensionLength = dimensionLength;
-        this.orderedAt = orderedAt;
         this.currentStatus = currentStatus;
         this.itemContentsType = itemContentsType;
         this.serviceType = serviceType;
@@ -171,7 +165,6 @@ public class Order extends BaseTimeEntity {
             .dimensionWidth(BigDecimal.valueOf(dto.dimensionWidth()))
             .dimensionHeight(BigDecimal.valueOf(dto.dimensionHeight()))
             .dimensionLength(BigDecimal.valueOf(dto.dimensionLength()))
-            .orderedAt(LocalDateTime.now())
             .deleted(false)
             .currentStatus(OrderStatus.PENDING)
             .itemContentsType(dto.itemContentsType())

--- a/src/main/java/org/example/oshipserver/domain/order/entity/OrderSender.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/OrderSender.java
@@ -28,16 +28,15 @@ public class OrderSender {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 추후 seller와의 연관관계 매핑
-    private Long sellerId;
-
-    private String storePlatform;
-    private String storeName;
     private String senderName;
     private String senderCompany;
     private String senderEmail;
     private String senderPhoneNo;
 
+    private String storePlatform;
+    private String storeName;
+
+    private Long sellerId;  // 추후 seller 연관관계 대체 예정
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id", nullable = false)
@@ -45,24 +44,23 @@ public class OrderSender {
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "sender_address_id")
-    private SenderAddress address;
+    private SenderAddress senderAddress;
 
     public void assignOrder(Order order) {
         this.order = order;
     }
 
     public void updateFrom(OrderUpdateRequest req) {
-        this.storePlatform = req.storePlatform();
-        this.storeName = req.storeName();
         this.senderName = req.senderName();
         this.senderCompany = req.senderCompany();
         this.senderEmail = req.senderEmail();
         this.senderPhoneNo = req.senderPhoneNo();
+        this.storePlatform = req.storePlatform();
+        this.storeName = req.storeName();
         this.sellerId = req.sellerId();
 
-        // address가 없으면 새로 생성
-        if (this.address == null) {
-            this.address = SenderAddress.builder()
+        if (this.senderAddress == null) {
+            this.senderAddress = SenderAddress.builder()
                 .senderCountryCode(req.senderCountryCode())
                 .senderState(req.senderState())
                 .senderStateCode(req.senderStateCode())
@@ -73,8 +71,7 @@ public class OrderSender {
                 .senderTaxId(req.senderTaxId())
                 .build();
         } else {
-            this.address.updateFrom(req);
+            this.senderAddress.updateFrom(req);
         }
     }
-
 }

--- a/src/main/java/org/example/oshipserver/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/order/repository/OrderRepository.java
@@ -1,6 +1,9 @@
 package org.example.oshipserver.domain.order.repository;
 
+import java.time.LocalDateTime;
 import org.example.oshipserver.domain.order.entity.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,6 +11,8 @@ import org.springframework.stereotype.Repository;
 public interface OrderRepository extends JpaRepository<Order,Long> {
     boolean existsByOrderNoAndSellerId(String orderNo, Long sellerId);
     boolean existsByOshipMasterNo(String masterNo);
+    Page<Order> findBySellerIdAndCreatedAtBetween(Long sellerId, LocalDateTime start, LocalDateTime end, Pageable pageable);
+    Page<Order> findByCreatedAtBetween(LocalDateTime start, LocalDateTime end, Pageable pageable);
 
 }
 


### PR DESCRIPTION
## ✏️ Issue
Closes #37 

## ☑️ Todo
- [ ] 주문 상세 조회
- [ ] 주문 목록 조회
- [ ] MasterNo 중복 시 Repository 에서 확인 후 다시 생성하도록 변경 구현

## ✅ Test Result
![image](https://github.com/user-attachments/assets/c649a652-6f7e-4b47-8234-d214926a6f94)

![image](https://github.com/user-attachments/assets/a1db9b26-5c6a-44c4-9b53-61cff2f94e98)

## 💌 Reviewer Notes
수정사항 있다면 알려주세요 ~