### PR TITLE
✨ [feat] 단건 결제 조회 api 생성 

### DIFF
--- a/src/main/java/org/example/oshipserver/client/toss/TossPaymentClient.java
+++ b/src/main/java/org/example/oshipserver/client/toss/TossPaymentClient.java
@@ -25,7 +25,7 @@ public class TossPaymentClient { // 외부 연동 모듈
 
     // 요청 url 생성
     private static final String TOSS_CONFIRM_URL = "https://api.tosspayments.com/v1/payments/confirm";
-    private static final String TOSS_LOOKUP_URL_PREFIX = "https://api.tosspayments.com/v1/payments/orders/";
+    private static final String TOSS_LOOKUP_URL_PREFIX = "https://api.tosspayments.com/v1/payments/";
 
     /**
      * Toss 단건 결제 승인 요청
@@ -65,8 +65,8 @@ public class TossPaymentClient { // 외부 연동 모듈
     /**
      * Toss 단건 결제 조회 요청
      */
-    public TossSinglePaymentLookupResponse requestSinglePaymentLookup(String orderId) {
-        String url = TOSS_LOOKUP_URL_PREFIX + orderId;
+    public TossSinglePaymentLookupResponse requestSinglePaymentLookup(String paymentKey) {
+        String url = TOSS_LOOKUP_URL_PREFIX + paymentKey;
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Basic " +

--- a/src/main/java/org/example/oshipserver/client/toss/TossPaymentClient.java
+++ b/src/main/java/org/example/oshipserver/client/toss/TossPaymentClient.java
@@ -3,6 +3,7 @@ package org.example.oshipserver.client.toss;
 import lombok.RequiredArgsConstructor;
 import org.example.oshipserver.domain.payment.dto.request.PaymentConfirmRequest;
 import org.example.oshipserver.domain.payment.dto.response.TossPaymentConfirmResponse;
+import org.example.oshipserver.domain.payment.dto.response.TossSinglePaymentLookupResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
@@ -22,10 +23,15 @@ public class TossPaymentClient { // 외부 연동 모듈
     @Value("${toss.secret-key}")
     private String tossSecretKey;
 
+    // 요청 url 생성
     private static final String TOSS_CONFIRM_URL = "https://api.tosspayments.com/v1/payments/confirm";
+    private static final String TOSS_LOOKUP_URL_PREFIX = "https://api.tosspayments.com/v1/payments/orders/";
 
+    /**
+     * Toss 단건 결제 승인 요청
+     */
     public TossPaymentConfirmResponse requestPaymentConfirm(PaymentConfirmRequest request) {
-        // 헤더 구성
+        // 인증 헤더 구성
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set("Authorization", "Basic " +
@@ -43,15 +49,39 @@ public class TossPaymentClient { // 외부 연동 모듈
         // 바디와 헤더를 하나로 묶은 HTTP 요청 객체
         HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
 
-        // RestTemplate으로 API 호출
+        // RestTemplate으로 POST 요청
         ResponseEntity<TossPaymentConfirmResponse> response = restTemplate.exchange(
-            TOSS_CONFIRM_URL,
+            TOSS_CONFIRM_URL,  // 재사용성을 위해 상수로 선언
             HttpMethod.POST,
             entity,
             TossPaymentConfirmResponse.class
         );
 
         // 응답 추출(토스 서버 응답을 TossPaymentConfirmResponse로 역직렬화)
+        return response.getBody();
+    }
+
+
+    /**
+     * Toss 단건 결제 조회 요청
+     */
+    public TossSinglePaymentLookupResponse requestSinglePaymentLookup(String orderId) {
+        String url = TOSS_LOOKUP_URL_PREFIX + orderId;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Basic " +
+            Base64.getEncoder().encodeToString((tossSecretKey + ":").getBytes())
+        );
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<TossSinglePaymentLookupResponse> response = restTemplate.exchange(
+            url,  // url을 동적으로 조립
+            HttpMethod.GET,
+            entity,
+            TossSinglePaymentLookupResponse.class
+        );
+
         return response.getBody();
     }
 }

--- a/src/main/java/org/example/oshipserver/domain/payment/controller/PaymentController.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/controller/PaymentController.java
@@ -3,6 +3,7 @@ package org.example.oshipserver.domain.payment.controller;
 import lombok.RequiredArgsConstructor;
 import org.example.oshipserver.domain.payment.dto.request.PaymentConfirmRequest;
 import org.example.oshipserver.domain.payment.dto.response.PaymentConfirmResponse;
+import org.example.oshipserver.domain.payment.dto.response.PaymentLookupResponse;
 import org.example.oshipserver.domain.payment.service.PaymentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +23,15 @@ public class PaymentController {
         @RequestBody PaymentConfirmRequest request
     ) {
         PaymentConfirmResponse response = paymentService.confirmPayment(request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 단건 결제 조회 (orderId)
+     */
+    @GetMapping("/orders/{orderId}")
+    public ResponseEntity<PaymentLookupResponse> getPaymentByOrderId(@PathVariable String orderId) {
+        PaymentLookupResponse response = paymentService.getPaymentByOrderId(orderId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentLookupResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentLookupResponse.java
@@ -7,7 +7,7 @@ import org.example.oshipserver.domain.payment.mapper.PaymentStatusMapper;
  * 결제 단건 조회 응답 DTO (내부 응답용)
  */
 public record PaymentLookupResponse(
-    String orderId,
+    String tossOrderId,
     String paymentKey,
     PaymentStatus paymentStatus,
     String paidAt,
@@ -23,7 +23,7 @@ public record PaymentLookupResponse(
     public static PaymentLookupResponse convertFromTossLookup(
         TossSinglePaymentLookupResponse response) {
         return new PaymentLookupResponse(
-            response.orderId(),
+            response.orderId(), // Toss 응답의 orderId를 tossOrderId로 매핑
             response.paymentKey(),
             PaymentStatusMapper.fromToss(response.status()),
             response.approvedAt(),

--- a/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentRepository.java
@@ -1,6 +1,7 @@
 package org.example.oshipserver.domain.payment.repository;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import org.example.oshipserver.domain.payment.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,4 +12,8 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     // paymentNo 생성용 : createdAt 기준으로 오늘 생성된 payment 개수 반환
     int countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+
+    // OrderId로 단건조회용
+    Optional<Payment> findByTossOrderId(String tossOrderId);
+
 }

--- a/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
@@ -9,7 +9,9 @@ import lombok.Builder;
 import org.example.oshipserver.client.toss.TossPaymentClient;
 import org.example.oshipserver.domain.payment.dto.request.PaymentConfirmRequest;
 import org.example.oshipserver.domain.payment.dto.response.PaymentConfirmResponse;
+import org.example.oshipserver.domain.payment.dto.response.PaymentLookupResponse;
 import org.example.oshipserver.domain.payment.dto.response.TossPaymentConfirmResponse;
+import org.example.oshipserver.domain.payment.dto.response.TossSinglePaymentLookupResponse;
 import org.example.oshipserver.domain.payment.entity.Payment;
 import org.example.oshipserver.domain.payment.entity.PaymentMethod;
 import org.example.oshipserver.domain.payment.entity.PaymentStatus;
@@ -29,6 +31,7 @@ public class PaymentService {
     private final TossPaymentClient tossPaymentClient;
     private final PaymentRepository paymentRepository;
 
+    // 단건 결제 생성 API
     public PaymentConfirmResponse confirmPayment(PaymentConfirmRequest request) {
 
         // 1. 중복 결제 여부 확인
@@ -71,6 +74,16 @@ public class PaymentService {
 
         // 7. 응답 DTO 반환
         return PaymentConfirmResponse.convertFromTossConfirm(tossResponse, method);
+    }
+
+    // 단건 결제 조회 API (orderId)
+    public PaymentLookupResponse getPaymentByOrderId(String orderId) {
+        Payment payment = paymentRepository.findByTossOrderId(orderId)
+            .orElseThrow(() -> new ApiException("해당 주문의 결제 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
+
+        TossSinglePaymentLookupResponse tossResponse = tossPaymentClient.requestSinglePaymentLookup(orderId);
+
+        return PaymentLookupResponse.convertFromTossLookup(tossResponse);
     }
 
 }

--- a/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
@@ -81,7 +81,9 @@ public class PaymentService {
         Payment payment = paymentRepository.findByTossOrderId(orderId)
             .orElseThrow(() -> new ApiException("해당 주문의 결제 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
 
-        TossSinglePaymentLookupResponse tossResponse = tossPaymentClient.requestSinglePaymentLookup(orderId);
+        // 클라이언트에게 받아온 orderId를 통해 db에서 paymentKey를 꺼내서 toss API에 넘기기
+        TossSinglePaymentLookupResponse tossResponse =
+            tossPaymentClient.requestSinglePaymentLookup(payment.getPaymentKey());
 
         return PaymentLookupResponse.convertFromTossLookup(tossResponse);
     }


### PR DESCRIPTION
## ✏️ Issue
Closes #42

## ☑️ Todo
paymentid를 통한 단건 결제 조회 api 생성

## ✅ Test Result
- 단건 결제 조회 성공
![단건결제조회성공](https://github.com/user-attachments/assets/119792b6-aaf5-4063-b155-aa0947c7097a)
- 단건 결제 조회 실패
![단건결제조회 실패](https://github.com/user-attachments/assets/c114f952-0fea-4686-8a83-7ee086fa0f00)

## 💌 Reviewer Notes
oss의 /v1/payments/orders/{orderId} API를 사용하려 했지만,
Toss에서 상점 인증 오류(NOT_FOUND_MERCHANT)로 차단되어 사용이 불가능
>> Toss에서 orderId 대신 paymentKey로만 조회 가능하여, 사용자에게 paymentKey가 노출되지 않도록 클라이언트에게 받은 orderId를 통해 db를 조회하여 paymentKey를 받아와서 조회하는 방식으로 리팩토링함