### PR TITLE
⚡️ [fix] #50Change barcode scan API from PathVariable to RequestParam

### DIFF
--- a/src/main/java/org/example/oshipserver/domain/shipping/controller/ShipmentController.java
+++ b/src/main/java/org/example/oshipserver/domain/shipping/controller/ShipmentController.java
@@ -23,8 +23,8 @@ public class ShipmentController {
 
     @PostMapping("/orders/{orderId}/carriers/{carrierId}")
     public BaseResponse<ShipmentCreateResponse> createShipment(
-            @PathVariable Long orderId,
-            @PathVariable Long carrierId) {
+        @PathVariable("orderId") Long orderId,
+        @PathVariable("carrierId") Long carrierId) {
 
         Long shipmentId = shipmentService.createShipment(orderId, carrierId);
         return new BaseResponse<>(201, "주문배송사연결성공", new ShipmentCreateResponse(shipmentId));


### PR DESCRIPTION
## ✏️ Issue
Closes #50 

## ☑️ Todo
주문바코드 스캔시, api url 에러가 생겼다.

기존 /api/v1/shipping/barcode/{barcode}
수정 /api/v1/shipping/barcode?barcode=GEM250605US1234567/1

수정 이유 : barcord의 값이 / 가 있다면 apu URL 에러로 해석

## ✅ Test Result
![image](https://github.com/user-attachments/assets/30f40b57-b573-4c45-a9df-dace8c2c183f)

