### PR TITLE
♻️ [refactor] #58 toss 멱등성 키 적용

### DIFF
--- a/src/main/java/org/example/oshipserver/client/toss/IdempotentRestClient.java
+++ b/src/main/java/org/example/oshipserver/client/toss/IdempotentRestClient.java
@@ -1,0 +1,43 @@
+package org.example.oshipserver.client.toss;
+
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class IdempotentRestClient { // 토스의 요청을 공통으로 처리
+
+    private final RestTemplate restTemplate;
+
+    @Value("${toss.secret-key}")
+    private String tossSecretKey;
+
+    public <T, R> R postForIdempotent(
+        String url,
+        T body,
+        Class<R> responseType,
+        String idempotencyKey
+    ) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", "Basic " +
+            Base64.getEncoder().encodeToString((tossSecretKey + ":").getBytes())
+        );
+        headers.set("Idempotency-Key", idempotencyKey); // 헤더에 멱등성 키!
+
+        HttpEntity<T> entity = new HttpEntity<>(body, headers);
+
+        ResponseEntity<R> response = restTemplate.exchange(
+            url,
+            HttpMethod.POST,
+            entity,
+            responseType
+        );
+
+        return response.getBody();
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/payment/util/PaymentNoGenerator.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/util/PaymentNoGenerator.java
@@ -5,6 +5,7 @@ import java.time.format.DateTimeFormatter;
 
 public class PaymentNoGenerator {
     // 결제 생성시 우리 서버에서 생성해야하는 코드 (PAY-20240604-0001 형식)
+    // 결제 PK 및 Toss의 멱등성 KEY로 사용
     public static String generate(LocalDate date, int sequence) {
         String dateStr = date.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
         String seqStr = String.format("%04d", sequence); // 4자리 패딩


### PR DESCRIPTION
## ✏️ Issue
Closes #58 

## ☑️ Todo
- toss 단건결제승인 api에 멱등성키 적용
- 결제 중복 방지를 위한 IdempotentRestClient 유틸성 클라이언트 구현
- PaymentService.confirmPayment() 로직 내에 중복 결제 방지 로직 추가

## ✅ Test Result
![토스결제승인시 멱등성 확인](https://github.com/user-attachments/assets/22b52958-52f8-44f5-829e-7e67f952cae5)

## 💌 Reviewer Notes
다른 API에도 멱등성 key를 유동적으로 적용할 수 있도록 IdempotentRestClient를 컴포넌트화하여 구현했습니다
기존에 서버에서 생성하던, 결제pk인 payment no를 멱등성키로 활용하였습니다.