### PR TITLE
✨ [feat] #61 다건 결제 생성api 및 인증오류 해결

### DIFF
--- a/src/main/java/org/example/oshipserver/client/toss/IdempotentRestClient.java
+++ b/src/main/java/org/example/oshipserver/client/toss/IdempotentRestClient.java
@@ -6,31 +6,47 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import java.nio.charset.StandardCharsets;
 
 @Component
 @RequiredArgsConstructor
-public class IdempotentRestClient { // 토스의 요청을 공통으로 처리
+public class IdempotentRestClient { // 토스의 post 요청을 멱등성 방식으로 처리
 
     private final RestTemplate restTemplate;
 
     @Value("${toss.secret-key}")
     private String tossSecretKey;
 
+    /**
+     * 멱등성 post 요청 처리 메서드
+     * @param url
+     * @param body
+     * @param responseType
+     * @param idempotencyKey 멱등성 키
+     * @return Toss 응답객체
+     */
     public <T, R> R postForIdempotent(
         String url,
         T body,
         Class<R> responseType,
         String idempotencyKey
     ) {
+        // 헤더 설정
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // Authorization 헤더 설정
         headers.set("Authorization", "Basic " +
-            Base64.getEncoder().encodeToString((tossSecretKey + ":").getBytes())
+            Base64.getEncoder().encodeToString((tossSecretKey + ":").getBytes(StandardCharsets.UTF_8))
         );
+
+        // 멱등성 키 헤더 설정
         headers.set("Idempotency-Key", idempotencyKey); // 헤더에 멱등성 키!
 
+        // 요청 엔티티 구성
         HttpEntity<T> entity = new HttpEntity<>(body, headers);
 
+        // RestTemplate을 통해 post 요청
         ResponseEntity<R> response = restTemplate.exchange(
             url,
             HttpMethod.POST,

--- a/src/main/java/org/example/oshipserver/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/order/repository/OrderRepository.java
@@ -13,6 +13,5 @@ public interface OrderRepository extends JpaRepository<Order,Long> {
     boolean existsByOshipMasterNo(String masterNo);
     Page<Order> findBySellerIdAndCreatedAtBetween(Long sellerId, LocalDateTime start, LocalDateTime end, Pageable pageable);
     Page<Order> findByCreatedAtBetween(LocalDateTime start, LocalDateTime end, Pageable pageable);
-
 }
 

--- a/src/main/java/org/example/oshipserver/domain/payment/controller/PaymentController.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/controller/PaymentController.java
@@ -1,7 +1,9 @@
 package org.example.oshipserver.domain.payment.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.oshipserver.domain.payment.dto.request.MultiPaymentConfirmRequest;
 import org.example.oshipserver.domain.payment.dto.request.PaymentConfirmRequest;
+import org.example.oshipserver.domain.payment.dto.response.MultiPaymentConfirmResponse;
 import org.example.oshipserver.domain.payment.dto.response.PaymentConfirmResponse;
 import org.example.oshipserver.domain.payment.dto.response.PaymentLookupResponse;
 import org.example.oshipserver.domain.payment.service.PaymentService;
@@ -23,6 +25,17 @@ public class PaymentController {
         @RequestBody PaymentConfirmRequest request
     ) {
         PaymentConfirmResponse response = paymentService.confirmPayment(request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 다건 결제 승인 처리 (Toss 연동)
+     */
+    @PostMapping("/multi")
+    public ResponseEntity<MultiPaymentConfirmResponse> confirmMultiPayment(
+        @RequestBody MultiPaymentConfirmRequest request
+    ) {
+        MultiPaymentConfirmResponse response = paymentService.confirmMultiPayment(request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/request/MultiPaymentConfirmRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/request/MultiPaymentConfirmRequest.java
@@ -1,0 +1,14 @@
+package org.example.oshipserver.domain.payment.dto.request;
+
+import java.util.List;
+
+/**
+ * 다건 결제 승인 요청 DTO (Toss 결제 승인 API 요청용)
+ */
+public record MultiPaymentConfirmRequest(
+    String paymentKey,
+    List<MultiOrderRequest> orders,
+    String currency
+) {
+    public record MultiOrderRequest(String orderId, Integer amount) {}
+}

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/request/PaymentConfirmRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/request/PaymentConfirmRequest.java
@@ -1,7 +1,7 @@
 package org.example.oshipserver.domain.payment.dto.request;
 
 /**
- * 결제 승인 요청 DTO (Toss 결제 승인 API 요청용)
+ * 단건 결제 승인 요청 DTO (Toss 결제 승인 API 요청용)
  */
 public record PaymentConfirmRequest(
     String paymentKey,   // Toss에서 전달해주는 결제 고유 키

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/response/MultiPaymentConfirmResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/response/MultiPaymentConfirmResponse.java
@@ -1,0 +1,52 @@
+package org.example.oshipserver.domain.payment.dto.response;
+
+import java.util.List;
+import org.example.oshipserver.domain.payment.entity.PaymentMethod;
+import org.example.oshipserver.domain.payment.entity.PaymentStatus;
+import org.example.oshipserver.domain.payment.mapper.PaymentStatusMapper;
+import org.example.oshipserver.domain.payment.dto.response.TossPaymentConfirmResponse;
+
+
+/**
+ * 다건 결제 생성 응답 DTO (내부 응답용)
+ */
+public record MultiPaymentConfirmResponse(
+    List<String> orderIds,
+    String paymentKey,
+    PaymentStatus paymentStatus,
+    String approvedAt,
+    Integer totalAmount,
+    String currency,
+    String cardLast4Digits,
+    String receiptUrl
+) {
+
+    /**
+     * Toss 다건 결제 승인 응답을 내부 응답 DTO 변환
+     */
+    public static MultiPaymentConfirmResponse convertFromTossConfirm(
+        TossPaymentConfirmResponse response,
+        List<String> orderIds
+    ) {
+        return new MultiPaymentConfirmResponse(
+            orderIds,
+            response.paymentKey(),
+            PaymentStatusMapper.fromToss(response.status()),
+            response.approvedAt(),
+            response.totalAmount(),
+            response.currency(),
+            response.card() != null ? getLast4Digits(response.card().number()) : null,
+            response.receipt() != null ? response.receipt().url() : null
+        );
+    }
+
+    /**
+     * 카드 번호에서 마지막 4자리 추출
+     */
+    private static String getLast4Digits(String cardNumber) {
+        if (cardNumber != null && cardNumber.length() >= 4) {
+            return cardNumber.substring(cardNumber.length() - 4);
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
@@ -5,16 +5,20 @@ import java.awt.font.TextHitInfo;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.Builder;
 import org.example.oshipserver.client.toss.TossPaymentClient;
+import org.example.oshipserver.domain.payment.dto.request.MultiPaymentConfirmRequest;
 import org.example.oshipserver.domain.payment.dto.request.PaymentConfirmRequest;
+import org.example.oshipserver.domain.payment.dto.response.MultiPaymentConfirmResponse;
 import org.example.oshipserver.domain.payment.dto.response.PaymentConfirmResponse;
 import org.example.oshipserver.domain.payment.dto.response.PaymentLookupResponse;
 import org.example.oshipserver.domain.payment.dto.response.TossPaymentConfirmResponse;
 import org.example.oshipserver.domain.payment.dto.response.TossSinglePaymentLookupResponse;
 import org.example.oshipserver.domain.payment.entity.Payment;
 import org.example.oshipserver.domain.payment.entity.PaymentMethod;
+import org.example.oshipserver.domain.payment.entity.PaymentOrder;
 import org.example.oshipserver.domain.payment.entity.PaymentStatus;
 import org.example.oshipserver.domain.payment.mapper.PaymentMethodMapper;
 import org.example.oshipserver.domain.payment.mapper.PaymentStatusMapper;
@@ -25,6 +29,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.example.oshipserver.global.exception.ApiException;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -34,7 +39,8 @@ public class PaymentService {
     private final TossPaymentClient tossPaymentClient;
     private final PaymentRepository paymentRepository;
 
-    // 단건 결제 승인 요청 (멱등성 키 적용)
+
+    // 단건 결제 승인 요청 (Toss 결제 위젯을 통한 요청 처리)
     public PaymentConfirmResponse confirmPayment(PaymentConfirmRequest request) {
 
         // 1. DB 기준 중복 확인
@@ -85,6 +91,62 @@ public class PaymentService {
         // 7. 응답 DTO 반환
         return PaymentConfirmResponse.convertFromTossConfirm(tossResponse, method);
     }
+
+    // 다건 결제 승인 요청 (Toss 결제 위젯을 통한 요청 처리)
+    @Transactional
+    public MultiPaymentConfirmResponse confirmMultiPayment(MultiPaymentConfirmRequest request) {
+        // 1. 이미 동일한 paymentKey로 결제가 처리된 경우 예외 발생
+        if (paymentRepository.existsByPaymentKey(request.paymentKey())) {
+            throw new ApiException("이미 처리된 결제입니다.", ErrorType.DUPLICATED_PAYMENT);
+        }
+
+        // 2. 오늘 날짜 기준으로 생성된 결제 건 수 조회 >> 고유 paymentNo 생성
+        LocalDate today = LocalDate.now();
+        int todayCount = paymentRepository.countByCreatedAtBetween(
+            today.atStartOfDay(), today.plusDays(1).atStartOfDay()
+        );
+        String paymentNo = PaymentNoGenerator.generate(today, todayCount + 1);
+
+        // 3. Toss 결제 승인 api 호출
+        TossPaymentConfirmResponse tossResponse;
+        try {
+            tossResponse = tossPaymentClient.requestPaymentConfirm(
+                new PaymentConfirmRequest(
+                    request.paymentKey(),
+                    request.orders().get(0).orderId(),
+                    request.orders().stream().mapToInt(MultiPaymentConfirmRequest.MultiOrderRequest::amount).sum()
+                ),
+                paymentNo
+            );
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode() == HttpStatus.CONFLICT) {
+                throw new ApiException("이미 처리된 결제입니다.", ErrorType.DUPLICATED_PAYMENT);
+            }
+            throw e;
+        }
+
+        // 4. toss 응답 기반으로 payment 엔티티 생성 및 저장
+        Payment payment = Payment.builder()
+            .paymentNo(paymentNo)
+            .paymentKey(tossResponse.paymentKey())
+            .tossOrderId(tossResponse.orderId())  // Toss에서 내려준 orderId 사용
+            .amount(tossResponse.totalAmount())
+            .currency("KRW")
+            .method(PaymentMethod.CARD)
+            .paidAt(OffsetDateTime.parse(tossResponse.approvedAt()).toLocalDateTime())
+            .status(PaymentStatusMapper.fromToss(tossResponse.status()))
+            .build();
+
+        paymentRepository.save(payment);
+
+        // 5. 요청으로 들어온 각 주문의 orderId만 리스트로 추출하여 응답dto로 변환
+        List<String> orderIds = request.orders().stream()
+            .map(MultiPaymentConfirmRequest.MultiOrderRequest::orderId)
+            .toList();
+
+        return MultiPaymentConfirmResponse.convertFromTossConfirm(tossResponse, orderIds);
+    }
+
 
     // 단건 결제 조회 API (orderId)
     public PaymentLookupResponse getPaymentByOrderId(String orderId) {

--- a/src/main/java/org/example/oshipserver/global/exception/ErrorType.java
+++ b/src/main/java/org/example/oshipserver/global/exception/ErrorType.java
@@ -23,7 +23,8 @@ public enum ErrorType{
 
     // Payment 관련 에러
     DUPLICATED_PAYMENT(HttpStatus.BAD_REQUEST, "이미 처리된 결제입니다."),
-    INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "지원하지 않는 결제 방식입니다.");
+    INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "지원하지 않는 결제 방식입니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 주문 ID 형식입니다.");
 
     private final HttpStatus status;
     private final String desc;


### PR DESCRIPTION
.

## ✏️ Issue
Closes #61 

## ☑️ Todo
- 기존 멱등성 보장 코드 작성시 403 인증 오류 발생 
  -> 시크릿 키를 base62 인코딩할때 UTF-8 인코딩하지 않아서 인증 헤더에 문제가 발생한 것
  -> .getBytes(StandardCharsets.UTF_8) 로 수정하여 Toss 서버가 인증 정보를 정상 인식하도록 개선
- 다건 결제 생성 API : Toss에 대표 주문 ID와 총 금액만 전달 (실제 주문 목록은 서버 내부에서 저장)

## ✅ Test Result
- 다건 결제 생성 성공
![토스 다건 결제 생성 승인](https://github.com/user-attachments/assets/88c02472-1396-4e95-9b13-f0a3f545cf25)
- 다건 결제 생성 실패 (결제키 중복)
![토스결제승인시 멱등성 확인](https://github.com/user-attachments/assets/d966fddd-f82a-43d3-8267-2db835b3ddba)


## 💌 Reviewer Notes
토스에서 제공하는 orderId는 우리쪽 db의 pk가 아닌 프론트에서 생성된 문자열이기 때문에 파싱하면 NumberFormatException 발생함. toss 위젯에서 orderId를 문자열로 넘겨주는 구조에 맞춰야하기 때문에 일단 order 테이블을 조회하지않고 결제를 승인할 수 있도록 설계했음. 지금 구조는 프론트ui없이도 toss api만으로 테스트 가능한 구조로 맞춰진 것이고 나중엔 PaymenrOrder로 Order을 연결하기위해 별도 조회하는 로직으로 분리할 예정.
