### PR TITLE
✨ [feat] #77 셀러 주문 통계 대시보드 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
 
 	// excel
 	implementation 'org.apache.poi:poi-ooxml:5.2.3'
+
+	// cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/oshipserver/domain/order/controller/OrderStatsController.java
+++ b/src/main/java/org/example/oshipserver/domain/order/controller/OrderStatsController.java
@@ -25,5 +25,15 @@ public class OrderStatsController {
         OrderStatsResponse response = orderStatsService.getMonthlyStats(sellerId, month);
         return ResponseEntity.ok(new BaseResponse<>(200, "셀러 주문 통계 조회 성공", response));
     }
+
+    @GetMapping("/v2/seller-stats/monthly")
+    public ResponseEntity<BaseResponse<OrderStatsResponse>> getMonthlyStatsV2(
+        @RequestParam Long sellerId,
+        @RequestParam String month
+    ) {
+        OrderStatsResponse response = orderStatsService.getMonthlyStatsV2(sellerId, month);
+        return ResponseEntity.ok(new BaseResponse<>(200, "셀러 주문 통계 조회 성공 (v2 - 캐시 적용)", response));
+    }
+
 }
 

--- a/src/main/java/org/example/oshipserver/domain/order/controller/OrderStatsController.java
+++ b/src/main/java/org/example/oshipserver/domain/order/controller/OrderStatsController.java
@@ -1,0 +1,29 @@
+package org.example.oshipserver.domain.order.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.oshipserver.domain.order.dto.response.OrderStatsResponse;
+import org.example.oshipserver.domain.order.service.OrderStatsService;
+import org.example.oshipserver.global.common.response.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class OrderStatsController {
+
+    private final OrderStatsService orderStatsService;
+
+    @GetMapping("/v1/seller-stats/monthly")
+    public ResponseEntity<BaseResponse<OrderStatsResponse>> getMonthlyStats(
+        @RequestParam Long sellerId,
+        @RequestParam String month
+    ) {
+        OrderStatsResponse response = orderStatsService.getMonthlyStats(sellerId, month);
+        return ResponseEntity.ok(new BaseResponse<>(200, "셀러 주문 통계 조회 성공", response));
+    }
+}
+

--- a/src/main/java/org/example/oshipserver/domain/order/dto/response/OrderStatsResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/response/OrderStatsResponse.java
@@ -1,0 +1,35 @@
+package org.example.oshipserver.domain.order.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
+import org.example.oshipserver.domain.order.entity.enums.OrderStatus;
+
+public record OrderStatsResponse(
+    String month,
+    int totalOrders,
+    Map<OrderStatus, Long> statusCounts,
+    BigDecimal totalWeightKg,
+    Amount totalOrderValue,
+    Map<LocalDate, Long> dailyOrderCount
+) {
+    public static OrderStatsResponse from(
+        String month,
+        int totalOrders,
+        Map<OrderStatus, Long> statusCounts,
+        BigDecimal totalWeightKg,
+        long totalAmount,
+        Map<LocalDate, Long> dailyOrderCount
+    ) {
+        return new OrderStatsResponse(
+            month,
+            totalOrders,
+            statusCounts,
+            totalWeightKg,
+            new Amount(totalAmount, "KRW"),
+            dailyOrderCount
+        );
+    }
+
+    public record Amount(long amount, String currency) {}
+}

--- a/src/main/java/org/example/oshipserver/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/order/repository/OrderRepository.java
@@ -1,11 +1,14 @@
 package org.example.oshipserver.domain.order.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.example.oshipserver.domain.order.entity.Order;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,5 +18,27 @@ public interface OrderRepository extends JpaRepository<Order,Long> {
     Page<Order> findBySellerIdAndCreatedAtBetween(Long sellerId, LocalDateTime start, LocalDateTime end, Pageable pageable);
     Page<Order> findByCreatedAtBetween(LocalDateTime start, LocalDateTime end, Pageable pageable);
     Optional<Order> findByOshipMasterNo(String masterNo);
+
+    /**
+     * 특정 셀러의 지정된 월에 생성된 주문들을 조회
+     *
+     *
+     * @param sellerId 셀러의 고유 ID
+     * @param startOfMonth 조회 시작일
+     * @param endOfMonth   조회 종료일
+     * @return 조건에 부합하는 주문 목록
+     */
+    @Query("""
+    SELECT o FROM Order o
+    WHERE o.sellerId = :sellerId
+      AND o.deleted = false
+      AND o.createdAt BETWEEN :startOfMonth AND :endOfMonth
+""")
+    List<Order> findBySellerIdAndCreatedAtBetween(
+        @Param("sellerId") Long sellerId,
+        @Param("startOfMonth") LocalDateTime startOfMonth,
+        @Param("endOfMonth") LocalDateTime endOfMonth
+    );
+
 }
 

--- a/src/main/java/org/example/oshipserver/domain/order/service/OrderStatsService.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/OrderStatsService.java
@@ -1,0 +1,113 @@
+package org.example.oshipserver.domain.order.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.example.oshipserver.domain.order.dto.response.OrderStatsResponse;
+import org.example.oshipserver.domain.order.entity.Order;
+import org.example.oshipserver.domain.order.entity.enums.OrderStatus;
+import org.example.oshipserver.domain.order.repository.OrderRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderStatsService {
+
+    private final OrderRepository orderRepository;
+
+    /**
+     * 셀러의 월간 주문 통계를 조회
+     *
+     * 1. 월 시작일 ~ 말일 범위로 주문 데이터를 조회하고,
+     * 2. 해당 데이터를 바탕으로 총 주문 수, 총 중량, 총 금액, 상태별 건수, 일자별 건수를 집계
+     *
+     * @param sellerId 통계를 조회할 셀러 ID
+     * @param monthStr 조회할 기준 월 ("yyyy-MM" 형식)
+     * @return 통계 응답 DTO (OrderStatsResponse)
+     */
+    public OrderStatsResponse getMonthlyStats(Long sellerId, String monthStr) {
+        // 입력된 문자열을 기반으로 연월을 파싱
+        YearMonth month = YearMonth.parse(monthStr);
+
+        // 해당 월의 시작일과 종료일을 LocalDateTime으로 계산
+        LocalDateTime start = month.atDay(1).atStartOfDay();            // ex) 2024-06-01T00:00
+        LocalDateTime end = month.atEndOfMonth().atTime(LocalTime.MAX); // ex) 2024-06-30T23:59:59.999...
+
+        // 조건에 맞는 주문 목록 조회 (삭제되지 않은 주문만)
+        List<Order> orders = orderRepository.findBySellerIdAndCreatedAtBetween(sellerId, start, end);
+
+        // 결과 집계 후 DTO 생성 및 반환
+        return OrderStatsResponse.from(
+            monthStr,
+            orders.size(),
+            getStatusCounts(orders),
+            getTotalWeight(orders),
+            getTotalAmount(orders),
+            getDailyOrderCount(orders)
+        );
+    }
+
+    /**
+     * 주문 상태별 건수를 계산
+     * 예: PENDING 10건, SHIPPED 8건 등
+     *
+     * @param orders 주문 리스트
+     * @return 상태별 주문 수 집계 Map
+     */
+    private Map<OrderStatus, Long> getStatusCounts(List<Order> orders) {
+        return orders.stream()
+            .collect(Collectors.groupingBy(Order::getCurrentStatus, Collectors.counting()));
+    }
+
+    /**
+     * 전체 주문의 실제 중량 합계를 계산
+     * - null 값은 제외
+     *
+     * @param orders 주문 리스트
+     * @return 총 중량 (Kg)
+     */
+    private BigDecimal getTotalWeight(List<Order> orders) {
+        return orders.stream()
+            .map(Order::getShipmentActualWeight)
+            .filter(weight -> weight != null)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /**
+     * 전체 주문의 총 금액을 계산
+     * - 각 주문의 아이템별 (단가 × 수량)을 합산
+     * - 금액 단위는 KRW 기준이라고 가정
+     *
+     * @param orders 주문 리스트
+     * @return 총 금액 (long, 단위: KRW)
+     */
+    private long getTotalAmount(List<Order> orders) {
+        return orders.stream()
+            .flatMap(order -> order.getOrderItems().stream())  // 모든 주문의 아이템 평탄화
+            .map(item -> item.getUnitValue()  // 단가
+                .multiply(BigDecimal.valueOf(item.getQuantity()))) // 단가 × 수량
+            .reduce(BigDecimal.ZERO, BigDecimal::add) // 합산
+            .longValue(); // 최종 long 변환 (소수점 버림)
+    }
+
+    /**
+     * 일자별 주문 수를 집계
+     * - 주문의 생성 일자(createdAt 기준)를 기준으로 그룹핑
+     *
+     * @param orders 주문 리스트
+     * @return 날짜별 주문 수 Map (예: 2024-06-01 → 5건)
+     */
+    private Map<LocalDate, Long> getDailyOrderCount(List<Order> orders) {
+        return orders.stream()
+            .collect(Collectors.groupingBy(
+                order -> order.getCreatedAt().toLocalDate(),
+                Collectors.counting()
+            ));
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/order/service/OrderStatsService.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/OrderStatsService.java
@@ -13,6 +13,7 @@ import org.example.oshipserver.domain.order.dto.response.OrderStatsResponse;
 import org.example.oshipserver.domain.order.entity.Order;
 import org.example.oshipserver.domain.order.entity.enums.OrderStatus;
 import org.example.oshipserver.domain.order.repository.OrderRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -52,6 +53,17 @@ public class OrderStatsService {
             getDailyOrderCount(orders)
         );
     }
+
+    /**
+     * v2: 캐시 적용된 월별 통계 조회 API
+     * 캐시 키 예: seller:dashboard:123:202406
+     */
+    @Cacheable(value = "sellerStats", key = "'seller:dashboard:' + #sellerId + ':' + #monthStr.replace('-', '')")
+    public OrderStatsResponse getMonthlyStatsV2(Long sellerId, String monthStr) {
+        return getMonthlyStats(sellerId, monthStr);
+    }
+
+
 
     /**
      * 주문 상태별 건수를 계산

--- a/src/main/java/org/example/oshipserver/global/config/CacheConfig.java
+++ b/src/main/java/org/example/oshipserver/global/config/CacheConfig.java
@@ -1,0 +1,24 @@
+package org.example.oshipserver.global.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("sellerStats");
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+            .expireAfterWrite(10, TimeUnit.MINUTES)  // 캐시 유효 시간
+            .maximumSize(500));                      // 최대 캐시 항목 수
+        return cacheManager;
+    }
+}


### PR DESCRIPTION
## ✏️ Issue
Closes #77 
셀러가 특정 월에 대한 주문 통계를 확인할 수 있는 API입니다.
주문 수, 상태별 건수, 총 중량, 총 금액, 일별 주문 추이를 한 번에 제공합니다.

## ☑️ Todo
- [ ] 셀러가 대시보드에서 확인하는 월간 주문 통계


## ✅ Test Result
![image](https://github.com/user-attachments/assets/948b7f31-fa45-41a8-a411-99e144f0ead6)

## 💌 Reviewer Notes
통화 단위 (예: KRW) 를 원화로 맞추었는데 관련해서 의견이 있으시다면 주셔도 좋을 것 같습니다 !
++ 지난 달에 대한 정보는 캐싱처리를 하려고 계획 중이고, 배송 지연과 관련된 알림도 대시보드에서 다룰까 ,,, 생각만 해보았습니당 !