### PR TITLE
♻️ [refactor] 기존의 단건결제 tossOrderId와 orderId 구분

### DIFF
--- a/src/main/java/org/example/oshipserver/client/toss/TossPaymentClient.java
+++ b/src/main/java/org/example/oshipserver/client/toss/TossPaymentClient.java
@@ -37,7 +37,7 @@ public class TossPaymentClient { // 외부 연동 모듈
     public TossPaymentConfirmResponse requestPaymentConfirm(PaymentConfirmRequest request, String idempotencyKey) {
         Map<String, Object> body = Map.of(
             "paymentKey", request.paymentKey(),
-            "orderId", request.orderId(),
+            "orderId", request.tossOrderId(),
             "amount", request.amount(),
             "currency", "KRW"
         );

--- a/src/main/java/org/example/oshipserver/domain/payment/controller/PaymentController.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/controller/PaymentController.java
@@ -1,11 +1,13 @@
 package org.example.oshipserver.domain.payment.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.oshipserver.domain.payment.dto.request.MultiPaymentConfirmRequest;
 import org.example.oshipserver.domain.payment.dto.request.PaymentConfirmRequest;
 import org.example.oshipserver.domain.payment.dto.response.MultiPaymentConfirmResponse;
 import org.example.oshipserver.domain.payment.dto.response.PaymentConfirmResponse;
 import org.example.oshipserver.domain.payment.dto.response.PaymentLookupResponse;
+import org.example.oshipserver.domain.payment.dto.response.PaymentOrderListResponse;
 import org.example.oshipserver.domain.payment.service.PaymentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -40,11 +42,37 @@ public class PaymentController {
     }
 
     /**
-     * Toss 기준 결제 조회
+     * Toss 기준 결제 조회 (결제상태 확인용)
      */
-    @GetMapping("/orders/{tossOrderId}")
+    @GetMapping("/toss-order/{tossOrderId}")
     public ResponseEntity<PaymentLookupResponse> getPaymentByTossOrderId(@PathVariable String tossOrderId) {
         PaymentLookupResponse response = paymentService.getPaymentByTossOrderId(tossOrderId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Toss 기준 결제 조회 (주문 확인용) -> 해당 payment에 연결된 모든 order를 주문리스트로 반환
+     */
+    @GetMapping("/toss-order/{tossOrderId}/orders")
+    public ResponseEntity<List<PaymentOrderListResponse>> getOrdersByTossOrderId(@PathVariable String tossOrderId) {
+        List<PaymentOrderListResponse> response = paymentService.getOrdersByTossOrderId(tossOrderId);
+        return ResponseEntity.ok(response);
+    }
+
+
+    /**
+     * 내부 주문 기준 결제 조회
+     */
+    @GetMapping("/orders/{orderId}")
+    public ResponseEntity<PaymentLookupResponse> getPaymentByOrderId(@PathVariable Long orderId) {
+        PaymentLookupResponse response = paymentService.getPaymentByOrderId(orderId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 하나의 주문(orderId)에 연결된 모든 결제 조회
+    @GetMapping("/orders/{orderId}/payments")
+    public ResponseEntity<List<PaymentLookupResponse>> getAllPaymentsByOrderId(@PathVariable Long orderId) {
+        List<PaymentLookupResponse> response = paymentService.getAllPaymentsByOrderId(orderId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/example/oshipserver/domain/payment/controller/PaymentController.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/controller/PaymentController.java
@@ -40,11 +40,11 @@ public class PaymentController {
     }
 
     /**
-     * 단건 결제 조회 (orderId)
+     * Toss 기준 결제 조회
      */
-    @GetMapping("/orders/{orderId}")
-    public ResponseEntity<PaymentLookupResponse> getPaymentByOrderId(@PathVariable String orderId) {
-        PaymentLookupResponse response = paymentService.getPaymentByOrderId(orderId);
+    @GetMapping("/orders/{tossOrderId}")
+    public ResponseEntity<PaymentLookupResponse> getPaymentByTossOrderId(@PathVariable String tossOrderId) {
+        PaymentLookupResponse response = paymentService.getPaymentByTossOrderId(tossOrderId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/request/MultiPaymentConfirmRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/request/MultiPaymentConfirmRequest.java
@@ -7,8 +7,9 @@ import java.util.List;
  */
 public record MultiPaymentConfirmRequest(
     String paymentKey,
+    String tossOrderId,
     List<MultiOrderRequest> orders,
     String currency
 ) {
-    public record MultiOrderRequest(String orderId, Integer amount) {}
+    public record MultiOrderRequest(Long orderId, Integer amount) {}
 }

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/request/PaymentConfirmRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/request/PaymentConfirmRequest.java
@@ -5,7 +5,7 @@ package org.example.oshipserver.domain.payment.dto.request;
  */
 public record PaymentConfirmRequest(
     String paymentKey,   // Toss에서 전달해주는 결제 고유 키
-    String orderId, // 우리 서버에서 생성한 주문 id 받아온 것
-//    String tossOrderId,      // 우리 서버에서 생성한 주문 ID (현재 임의로 토스에서 받아온 값 사용)
+    Long orderId,        // 우리 서버에서 생성한 주문 id
+    String tossOrderId,  // 토스의 주문 id
     Integer amount       // (임시) 프론트 입력값. 나중엔 서버에서 계산하여 받아올 것 (이 필드를 제거하고, 서비스로직에서 orderId로 조회하여 amount 계산하여 Toss로 confirm 전달하도록)
 ) {}

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentConfirmResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentConfirmResponse.java
@@ -20,7 +20,7 @@ public record PaymentConfirmResponse(
 ) {
 
     /**
-     * Toss 단건 결제 승인 응답을 내부 응답 DTO 변환
+     * Toss 기준 단건 결제 승인 응답을 내부 응답 DTO로 변환
      */
     public static PaymentConfirmResponse convertFromTossConfirm(
         TossPaymentConfirmResponse response,

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentLookupResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentLookupResponse.java
@@ -1,5 +1,8 @@
 package org.example.oshipserver.domain.payment.dto.response;
 
+import java.util.List;
+import org.example.oshipserver.domain.order.entity.Order;
+import org.example.oshipserver.domain.payment.entity.Payment;
 import org.example.oshipserver.domain.payment.entity.PaymentStatus;
 import org.example.oshipserver.domain.payment.mapper.PaymentStatusMapper;
 
@@ -19,6 +22,7 @@ public record PaymentLookupResponse(
 
     /**
      * Toss 기준 단건 결제 조회 응답을 내부 응답 DTO로 변환
+     * toss에 직접 조회 요청했을 때 사용
      */
     public static PaymentLookupResponse convertFromTossLookup(
         TossSinglePaymentLookupResponse response) {
@@ -43,4 +47,18 @@ public record PaymentLookupResponse(
         }
         return null;
     }
+
+    public static PaymentLookupResponse fromPaymentAndOrders(Payment payment, List<Order> orders) {
+        return new PaymentLookupResponse(
+            payment.getTossOrderId(),
+            payment.getPaymentKey(),
+            payment.getStatus(),
+            payment.getPaidAt().toString(),
+            payment.getAmount(),
+            payment.getCurrency(),
+            payment.getCardLast4Digits(),
+            payment.getReceiptUrl()
+        );
+    }
+
 }

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentLookupResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentLookupResponse.java
@@ -18,7 +18,7 @@ public record PaymentLookupResponse(
 ) {
 
     /**
-     * Toss 단건 결제 조회 응답을 내부 응답 DTO 변환
+     * Toss 기준 단건 결제 조회 응답을 내부 응답 DTO로 변환
      */
     public static PaymentLookupResponse convertFromTossLookup(
         TossSinglePaymentLookupResponse response) {

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentOrderListResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentOrderListResponse.java
@@ -1,0 +1,27 @@
+package org.example.oshipserver.domain.payment.dto.response;
+
+import java.math.BigDecimal;
+import org.example.oshipserver.domain.order.entity.Order;
+import org.example.oshipserver.domain.order.entity.enums.OrderStatus;
+
+public record PaymentOrderListResponse(
+    Long orderId,
+    String orderNo,
+    int parcelCount,
+    BigDecimal shipmentActualWeight,
+    OrderStatus status,
+    String senderName,
+    String recipientName
+) {
+    public static PaymentOrderListResponse from(Order order) {
+        return new PaymentOrderListResponse(
+            order.getId(),
+            order.getOrderNo(),
+            order.getParcelCount(),
+            order.getShipmentActualWeight(),
+            order.getCurrentStatus(),
+            order.getSender() != null ? order.getSender().getSenderName() : null,
+            order.getRecipient() != null ? order.getRecipient().getRecipientName() : null
+        );
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/payment/entity/Payment.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/entity/Payment.java
@@ -72,8 +72,33 @@ public class Payment extends BaseTimeEntity {
 
     // 주문 여러건을 묶어서 결제 (다건 결제용)
     @OneToMany(mappedBy = "payment", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PaymentOrder> orders = new ArrayList<>();
+    private List<PaymentOrder> paymentOrders = new ArrayList<>();
 
+    // 직접 매핑된 주문 리스트만 추출
+    public List<Order> getOrders() {
+        return paymentOrders.stream()
+            .map(PaymentOrder::getOrder)
+            .toList();
+    }
+
+    private String cardLast4Digits;
+    private String receiptUrl;
+
+    public String getCardLast4Digits() {
+        return cardLast4Digits;
+    }
+
+    public String getReceiptUrl() {
+        return receiptUrl;
+    }
+
+    public void setCardLast4Digits(String cardLast4Digits) {
+        this.cardLast4Digits = cardLast4Digits;
+    }
+
+    public void setReceiptUrl(String receiptUrl) {
+        this.receiptUrl = receiptUrl;
+    }
 
     @Builder
     public Payment(String paymentNo, String paymentKey, String tossOrderId,
@@ -90,10 +115,12 @@ public class Payment extends BaseTimeEntity {
         this.failReason = failReason;
     }
 
-    public void markSuccess(String paymentKey, LocalDateTime paidAt) {
+    public void markSuccess(String paymentKey, LocalDateTime paidAt, String cardLast4Digits, String receiptUrl) {
         this.paymentKey = paymentKey;
         this.status = PaymentStatus.COMPLETE;
         this.paidAt = paidAt;
+        this.cardLast4Digits = cardLast4Digits;
+        this.receiptUrl = receiptUrl;
     }
 
     public void markFailed(String reason) {

--- a/src/main/java/org/example/oshipserver/domain/payment/entity/PaymentOrder.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/entity/PaymentOrder.java
@@ -17,12 +17,12 @@ public class PaymentOrder extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 주문 여러 건을 하나의 결제에 묶기 위한 중간 테이블
+    // 결제와 연결 : 주문 여러 건을 하나의 결제에 묶기 위한 중간 테이블
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "payment_id", nullable = false)
     private Payment payment;
 
-    // 여러 개의 PaymentOrder는 하나의 Order를 가리킴 (승인 부분취소용)
+    // 주문과 연결 : 하나의 주문이 여러 PaymentOrder로 나뉠 수 있음 (부분결제, 부분취소, 재결제 등)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;

--- a/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentOrderRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentOrderRepository.java
@@ -9,13 +9,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PaymentOrderRepository extends JpaRepository<PaymentOrder, Long> {
 
 
-    // tossOrderId 기준으로 결제 리스트로 조회
-    List<PaymentOrder> findAllByPayment(Payment payment);
+    // 하나의 결제(Payment)에 연결된 모든 주문 매핑(PaymentOrder)을 조회
+    List<PaymentOrder> findAllByPayment_Id(Long paymentId);
 
     // 내부 orderId 기준으로 PaymentOrder 조회
     Optional<PaymentOrder> findByOrder_Id(Long orderId);
 
-    // 하나의 주문(orderId)에 연결된 모든 결제 매핑 조회
+    // 하나의 주문(orderId)에 연결된 모든 PaymentOrder 조회
     List<PaymentOrder> findAllByOrder_Id(Long orderId);
 
 }

--- a/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentOrderRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentOrderRepository.java
@@ -1,0 +1,21 @@
+package org.example.oshipserver.domain.payment.repository;
+
+import java.util.List;
+import java.util.Optional;
+import org.example.oshipserver.domain.payment.entity.Payment;
+import org.example.oshipserver.domain.payment.entity.PaymentOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentOrderRepository extends JpaRepository<PaymentOrder, Long> {
+
+
+    // tossOrderId 기준으로 결제 리스트로 조회
+    List<PaymentOrder> findAllByPayment(Payment payment);
+
+    // 내부 orderId 기준으로 PaymentOrder 조회
+    Optional<PaymentOrder> findByOrder_Id(Long orderId);
+
+    // 하나의 주문(orderId)에 연결된 모든 결제 매핑 조회
+    List<PaymentOrder> findAllByOrder_Id(Long orderId);
+
+}

--- a/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentRepository.java
@@ -3,6 +3,7 @@ package org.example.oshipserver.domain.payment.repository;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.example.oshipserver.domain.payment.entity.Payment;
+import org.example.oshipserver.domain.payment.entity.PaymentOrder;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {

--- a/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentRepository.java
@@ -13,7 +13,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     // paymentNo 생성용 : createdAt 기준으로 오늘 생성된 payment 개수 반환
     int countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
 
-    // OrderId로 단건조회용
+    // tossOrderId로 조회(toss 기준의 결제 단위 조회)
     Optional<Payment> findByTossOrderId(String tossOrderId);
 
 }

--- a/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
@@ -148,9 +148,11 @@ public class PaymentService {
     }
 
 
-    // 단건 결제 조회 API (orderId)
-    public PaymentLookupResponse getPaymentByOrderId(String orderId) {
-        Payment payment = paymentRepository.findByTossOrderId(orderId)
+    // tossOrderId로 결제 조회(toss 기준의 결제 단위 조회)
+    // 단건 조회 또는 다건(대표 orderId) 조회
+    @Transactional(readOnly = true)
+    public PaymentLookupResponse getPaymentByTossOrderId(String tossOrderId) {
+        Payment payment = paymentRepository.findByTossOrderId(tossOrderId)
             .orElseThrow(() -> new ApiException("해당 주문의 결제 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
 
         // 클라이언트에게 받아온 orderId를 통해 db에서 paymentKey를 꺼내서 toss API에 넘기기


### PR DESCRIPTION
## ✏️ Issue
Closes #69

## ☑️ Todo
결제 생성시 내부 엔티티 생성되어 조회할때 내부 주문정보 함께 조회되도록, 내부 orderId와 외부 api의 orderId 구분하기

## ✅ Test Result
request body 수정되었습니다
![image](https://github.com/user-attachments/assets/b4efe363-e611-46f7-a420-68b0b8ddf458)
![image](https://github.com/user-attachments/assets/db5043a3-8050-4440-ad0f-6e4c399c53e1)
- 주문상세조회 
![image](https://github.com/user-attachments/assets/515ebc0c-a8dc-45ab-b7a1-e46ed4c8e717)


## 💌 Reviewer Notes
일단 결제내역조회시 paymentOrder테이블 생성되어 오더정보 가져와짐
이후에 세부적인 리팩토링 필요
