### PR TITLE
✨ [feat] #89 주문 취소 이력 조회 api 구현

### DIFF
--- a/src/main/java/org/example/oshipserver/domain/payment/controller/PaymentController.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/controller/PaymentController.java
@@ -6,6 +6,7 @@ import org.example.oshipserver.domain.payment.dto.request.MultiPaymentConfirmReq
 import org.example.oshipserver.domain.payment.dto.request.PaymentCancelRequest;
 import org.example.oshipserver.domain.payment.dto.request.PaymentConfirmRequest;
 import org.example.oshipserver.domain.payment.dto.response.MultiPaymentConfirmResponse;
+import org.example.oshipserver.domain.payment.dto.response.PaymentCancelHistoryResponse;
 import org.example.oshipserver.domain.payment.dto.response.PaymentConfirmResponse;
 import org.example.oshipserver.domain.payment.dto.response.PaymentLookupResponse;
 import org.example.oshipserver.domain.payment.dto.response.PaymentOrderListResponse;
@@ -76,8 +77,17 @@ public class PaymentController {
     }
 
     /**
-     * 내부 주문 기준 결제 조회
+     * Toss 결제 취소 이력 조회
      */
+    @GetMapping("/{paymentKey}/cancel-history")
+    public ResponseEntity<List<PaymentCancelHistoryResponse>> getCancelHistory(
+        @PathVariable String paymentKey
+    ) {
+        List<PaymentCancelHistoryResponse> histories = paymentService.getCancelHistory(paymentKey);
+        return ResponseEntity.ok(histories);
+    }
+
+    // 내부 주문 기준 결제 조회
     @GetMapping("/orders/{orderId}")
     public ResponseEntity<PaymentLookupResponse> getPaymentByOrderId(@PathVariable Long orderId) {
         PaymentLookupResponse response = paymentService.getPaymentByOrderId(orderId);

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentCancelHistoryResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentCancelHistoryResponse.java
@@ -1,0 +1,19 @@
+package org.example.oshipserver.domain.payment.dto.response;
+
+import java.time.LocalDateTime;
+import org.example.oshipserver.domain.payment.entity.PaymentCancelHistory;
+
+public record PaymentCancelHistoryResponse(
+    int cancelAmount,
+    String cancelReason,
+    LocalDateTime canceledAt
+) {
+    public static PaymentCancelHistoryResponse fromEntity(PaymentCancelHistory history) {
+        return new PaymentCancelHistoryResponse(
+            history.getCancelAmount(),
+            history.getCancelReason(),
+            history.getCanceledAt()
+        );
+    }
+}
+

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentCancelHistoryResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentCancelHistoryResponse.java
@@ -2,17 +2,20 @@ package org.example.oshipserver.domain.payment.dto.response;
 
 import java.time.LocalDateTime;
 import org.example.oshipserver.domain.payment.entity.PaymentCancelHistory;
+import org.example.oshipserver.domain.payment.entity.PaymentStatus;
 
 public record PaymentCancelHistoryResponse(
     int cancelAmount,
     String cancelReason,
-    LocalDateTime canceledAt
+    LocalDateTime canceledAt,
+    PaymentStatus paymentStatus
 ) {
     public static PaymentCancelHistoryResponse fromEntity(PaymentCancelHistory history) {
         return new PaymentCancelHistoryResponse(
             history.getCancelAmount(),
             history.getCancelReason(),
-            history.getCanceledAt()
+            history.getCanceledAt(),
+            history.getPayment().getStatus()
         );
     }
 }

--- a/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
@@ -271,14 +271,18 @@ public class PaymentService {
             payment.cancel();
             paymentRepository.save(payment);
 
-            // 주문 상태도 함께 변경
+            // 전체취소일때는 주문 상태도 함께 변경
             List<PaymentOrder> orders = paymentOrderRepository.findAllByPayment_Id(payment.getId());
             for (PaymentOrder paymentOrder : orders) {
                 paymentOrder.cancel();
             }
+
+            // 취소 이력 저장
+            PaymentCancelHistory history = PaymentCancelHistory.create(payment, payment.getAmount(), cancelReason);
+            paymentCancelHistoryRepository.save(history);
         } else {
             // 부분 취소
-            payment.partialCancel(cancelAmount, cancelReason);
+            payment.partialCancel(cancelAmount, cancelReason);  // 결제상태만 변경 (주문상태는 그대로 둠)
             paymentRepository.save(payment);
 
             //  부분 취소 이력 저장

--- a/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
@@ -337,11 +337,14 @@ public class PaymentService {
      * 결제 취소 이력 조회
      */
     public List<PaymentCancelHistoryResponse> getCancelHistory(String paymentKey) {
+        // 1. 결제 정보 조회
         Payment payment = paymentRepository.findByPaymentKey(paymentKey)
             .orElseThrow(() -> new ApiException("결제 정보가 없습니다.", ErrorType.NOT_FOUND));
 
+        // 2. 취소이력 조회
         List<PaymentCancelHistory> histories = paymentCancelHistoryRepository.findByPayment(payment);
 
+        // 3. DTO 변환
         return histories.stream()
             .map(PaymentCancelHistoryResponse::fromEntity)
             .toList();

--- a/src/main/java/org/example/oshipserver/global/exception/ErrorType.java
+++ b/src/main/java/org/example/oshipserver/global/exception/ErrorType.java
@@ -25,6 +25,8 @@ public enum ErrorType{
     // Payment 관련 에러
     DUPLICATED_PAYMENT(HttpStatus.BAD_REQUEST, "이미 처리된 결제입니다."),
     INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "지원하지 않는 결제 방식입니다."),
+    ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 전체 금액이 취소되었습니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청이 올바르지 않습니다."),
 
     // Shipping/Barcode 관련 에러
     BARCODE_NOT_PRINTED(HttpStatus.BAD_REQUEST, "바코드가 출력되지 않았습니다."),


### PR DESCRIPTION
## ✏️ Issue
Closes #89

## ☑️ Todo
- 프론트에서 주문 취소 이력 조회할 수 있도록 api 구현
- 누적 취소금액이 총 결제금액 초과하지 않도록 기존 로직 보완
- paymentStatus를 통해 전체/부분 취소 구분 가능

## ✅ Test Result
- 총 결제금액(50,000)보다 취소금액보다 큰 문제에 대하여, 로직 수정하여 에러 해결
문제상황과 해결화면
![총결제금액(50,000)보다 취소금액이 더 큰 문제에 대하여](https://github.com/user-attachments/assets/d8cd6e87-e2a7-48b6-8558-39dda558d73a)
![에러해결](https://github.com/user-attachments/assets/6087f116-9e3e-428b-b7d9-d28c96d4ef1b)

- 결제 취소 이력 성공화면 (최종)
![결제 취소 이력 조회](https://github.com/user-attachments/assets/2063b8b3-0e02-4963-8981-a80f20f2926b)


## 💌 Reviewer Notes
현재 결제 취소 시 누적 취소금액을 이력 기반으로 실시간 계산하여, 총 취소금액이 총 결제금액을 초과하지 않도록 제어하고 있습니다.
(ex. 부분 취소 이후 전체취소시, 부분 취소하고 남은 금액이 취소됩니다. 서버와 toss 모두 동일함)
이후에 이 누적 취소 금액을 별도의 필드로 캐싱하거나, 취소 이력을 기반으로 잔액을 계산하는 기능으로 확장 가능합니다.