### PR TITLE
✨ [feat] #101 Toss API 오류 응답 처리 및 ApiException으로 예외 흐름 개선

### DIFF
--- a/src/main/java/org/example/oshipserver/client/toss/IdempotentRestClient.java
+++ b/src/main/java/org/example/oshipserver/client/toss/IdempotentRestClient.java
@@ -2,6 +2,7 @@ package org.example.oshipserver.client.toss;
 
 import java.util.Base64;
 import lombok.RequiredArgsConstructor;
+import org.example.oshipserver.global.exception.ApiException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
@@ -65,14 +66,14 @@ public class IdempotentRestClient { // 토스의 post 요청을 멱등성 방식
 
         } catch (HttpClientErrorException | HttpServerErrorException e) {
             // Toss API에서 에러 응답이 온 경우
-            System.err.println("[Toss 에러 응답] 상태코드: " + e.getStatusCode());
+            System.err.println("[Toss 호출 실패] 상태코드: " + e.getStatusCode());
             System.err.println("[Toss 에러 바디] " + e.getResponseBodyAsString());
-            throw e; // 혹은 CustomException으로 감싸서 throw
+            throw new ApiException("Toss 호출 실패: " + e.getResponseBodyAsString(), e);
         } catch (Exception e) {
             // 네트워크 오류 등 기타 예외
             System.err.println("[Toss 호출 예외 발생] " + e.getMessage());
             e.printStackTrace();
-            throw e;
+            throw new ApiException("Toss 호출 중 알 수 없는 오류 발생", e);
         }
     }
 }

--- a/src/main/java/org/example/oshipserver/global/exception/ApiException.java
+++ b/src/main/java/org/example/oshipserver/global/exception/ApiException.java
@@ -10,4 +10,18 @@ public class ApiException extends RuntimeException{
 
     private final String message;
     private final ErrorType errorType;
+
+    // 외부 오류용(Toss): ErrorType 없이 message만 전달
+    public ApiException(String message) {
+        super(message);
+        this.message = message;
+        this.errorType = ErrorType.INTERNAL_SERVER_ERROR;
+    }
+
+    // 외부 오류용(Toss) : e.getResponseBodyAsString()과 함께 전달
+    public ApiException(String message, Throwable cause) {
+        super(message, cause);
+        this.message = message;
+        this.errorType = ErrorType.INTERNAL_SERVER_ERROR;
+    }
 }

--- a/src/main/java/org/example/oshipserver/global/exception/ErrorType.java
+++ b/src/main/java/org/example/oshipserver/global/exception/ErrorType.java
@@ -27,6 +27,7 @@ public enum ErrorType{
     INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "지원하지 않는 결제 방식입니다."),
     ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 전체 금액이 취소되었습니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청이 올바르지 않습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
 
     // Shipping/Barcode 관련 에러
     BARCODE_NOT_PRINTED(HttpStatus.BAD_REQUEST, "바코드가 출력되지 않았습니다."),


### PR DESCRIPTION
.

## ✏️ Issue
Closes #101

## ☑️ Todo

## ✅ Test Result

## 💌 Reviewer Notes

[Toss 성공 응답] TossPaymentConfirmResponse[mId=null, lastTransactionKey=null, paymentKey=null, orderId=null, orderName=null, taxExemptionAmount=0, status=null, requestedAt=null, approvedAt=null, useEscrow=false, cultureExpense=false, card=null, type=null, easyPay=null, country=null, failure=null, isPartialCancelable=false, receipt=null, checkout=null, currency=null, totalAmount=0, balanceAmount=0, suppliedAmount=0, vat=0, taxFreeAmount=0, method=null, version=null]
2025-06-13 12:01:58 [http-nio-8080-exec-6] INFO  o.e.o.domain.log.service.LogService - {"date":"2025-06-13 12:01:57","userId":1,"method":"POST","uri":"/api/v1/payments/multi","ip":"172.18.0.1","userAgent":"PostmanRuntime/7.44.0","duration":691,"status":400}

성공 응답이라고 뜨는데 responsebody가 null로 뜨는 것에 대하여 로그 추가
