### PR TITLE
✨ [feat] #113 알림 기능 구조 설계 및 Gmail SMTP 연동 테스트

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,10 @@ jobs:
       JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
       TOSS_SECRET_KEY: ${{ secrets.TOSS_SECRET_KEY }}
       FEDEX_API_URL: ${{secrets.FEDEX_API_URL}}
+      MAIL_HOST: ${{ secrets.MAIL_HOST }}
+      MAIL_PORT: ${{ secrets.MAIL_PORT }}
+      MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+      MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,6 +9,10 @@ jobs:
       JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
       TOSS_SECRET_KEY: ${{ secrets.TOSS_SECRET_KEY }}
       FEDEX_API_URL: ${{secrets.FEDEX_API_URL}}
+      MAIL_HOST: ${{ secrets.MAIL_HOST }}
+      MAIL_PORT: ${{ secrets.MAIL_PORT }}
+      MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+      MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'com.github.ben-manes.caffeine:caffeine'
 
+	// gmail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// sendgrid
+	// implementation 'com.sendgrid:sendgrid-java:4.9.3'
+
 	implementation 'org.apache.httpcomponents.client5:httpclient5'
 
 }

--- a/src/main/java/org/example/oshipserver/domain/notification/dto/NotificationRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/dto/NotificationRequest.java
@@ -1,0 +1,8 @@
+package org.example.oshipserver.domain.notification.dto;
+
+public record NotificationRequest(
+    String type,
+    String title,
+    String content,
+    Long sellerId
+) {}

--- a/src/main/java/org/example/oshipserver/domain/notification/entity/Notification.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/entity/Notification.java
@@ -1,0 +1,62 @@
+package org.example.oshipserver.domain.notification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "notification")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String type;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "target_email", nullable = false, length = 255)
+    private String targetEmail;
+
+    @Column
+    private Boolean sent;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void markAsSent() {
+        this.sent = true;
+        this.sentAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/org/example/oshipserver/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package org.example.oshipserver.domain.notification.repository;
+
+import org.example.oshipserver.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/org/example/oshipserver/domain/notification/service/EmailNotificationService.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/service/EmailNotificationService.java
@@ -1,0 +1,61 @@
+package org.example.oshipserver.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.oshipserver.domain.notification.dto.NotificationRequest;
+import org.example.oshipserver.domain.notification.entity.Notification;
+import org.example.oshipserver.domain.notification.repository.NotificationRepository;
+import org.example.oshipserver.domain.seller.entity.Seller;
+import org.example.oshipserver.domain.seller.repository.SellerRepository;
+import org.example.oshipserver.domain.user.entity.User;
+import org.example.oshipserver.domain.user.repository.UserRepository;
+import org.example.oshipserver.global.exception.ApiException;
+import org.example.oshipserver.global.exception.ErrorType;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class EmailNotificationService {
+
+    private final EmailSender emailSender;
+    private final NotificationRepository notificationRepository;
+    private final SellerRepository sellerRepository;
+    private final UserRepository userRepository;
+
+    public void send(NotificationRequest request) {
+        Notification notification = Notification.builder()
+            .type(request.type())
+            .title(request.title())
+            .content(request.content())
+            .sent(false)
+            .build();
+
+        try {
+            Seller seller = sellerRepository.findById(request.sellerId())
+                .orElseThrow(() -> new ApiException("셀러를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
+
+            User user = userRepository.findById(seller.getUserId())
+                .orElseThrow(() -> new ApiException("유저를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
+
+            String to = user.getEmail();
+
+            emailSender.send(
+                to,
+                request.title(),
+                request.content()
+            );
+
+            notification.markAsSent();
+
+            // setter 추후 수정 예정
+            notification.setTargetEmail(to);
+
+        } catch (Exception e) {
+            log.error("[알림 전송 실패] type={}, sellerId={}, reason={}",
+                request.type(), request.sellerId(), e.getMessage());
+        }
+
+        notificationRepository.save(notification);
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/notification/service/EmailSender.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/service/EmailSender.java
@@ -1,0 +1,5 @@
+package org.example.oshipserver.domain.notification.service;
+
+public interface EmailSender {
+    void send(String to, String subject, String content);
+}

--- a/src/main/java/org/example/oshipserver/domain/notification/service/GmailSmtpEmailSender.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/service/GmailSmtpEmailSender.java
@@ -1,0 +1,36 @@
+package org.example.oshipserver.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GmailSmtpEmailSender implements EmailSender {
+
+    private final JavaMailSender mailSender;
+
+    private static final String FROM_EMAIL = "oshipapp@gmail.com";
+
+    @Override
+    public void send(String to, String subject, String content) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(to);
+            message.setSubject(subject);
+            message.setText(content);
+            message.setFrom(FROM_EMAIL);
+
+            mailSender.send(message);
+
+            log.info("[Email 전송 성공] to={}, subject={}", to, subject);
+
+        } catch (Exception e) {
+            log.error("[Email 전송 실패] to={}, subject={}, reason={}", to, subject, e.getMessage());
+            throw new RuntimeException("Gmail SMTP 메일 전송 실패", e);
+        }
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/notification/service/NotificationTemplateFactory.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/service/NotificationTemplateFactory.java
@@ -1,0 +1,5 @@
+package org.example.oshipserver.domain.notification.service;
+
+public class NotificationTemplateFactory {
+
+}

--- a/src/main/java/org/example/oshipserver/domain/notification/test/NotificationTest.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/test/NotificationTest.java
@@ -1,0 +1,36 @@
+package org.example.oshipserver.domain.notification.test;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.oshipserver.domain.notification.dto.NotificationRequest;
+import org.example.oshipserver.domain.notification.service.EmailNotificationService;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@Profile("local") // 배포 환경에서는 실행되지 않도록 제한
+public class NotificationTest implements CommandLineRunner {
+
+    private final EmailNotificationService emailNotificationService;
+
+    @Override
+    public void run(String... args) throws Exception {
+        log.info("이메일 발송 테스트 시작...");
+
+        Long testSellerId = 1L; // 실제 이메일 연결된 sellerId
+        NotificationRequest request = new NotificationRequest(
+            "ORDER_PLACED",   // type
+            "[테스트] 주문 알림",   // title
+            "이것은 테스트 알림입니다.\n마스터 주문번호: TEST-123456", // content
+            testSellerId
+        );
+
+        // 알림 서비스 실행 (DB 저장 + 이메일 발송)
+        emailNotificationService.send(request);
+
+        log.info("테스트 이메일 발송 완료");
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/order/service/OrderService.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/OrderService.java
@@ -123,6 +123,8 @@ public class OrderService {
             ""
         );
 
+        // 9. 알림 전송 (이메일 발송)
+
         return masterNo;
     }
 

--- a/src/main/java/org/example/oshipserver/global/config/MailConfig.java
+++ b/src/main/java/org/example/oshipserver/global/config/MailConfig.java
@@ -1,0 +1,36 @@
+package org.example.oshipserver.global.config;
+
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.debug", "true");
+
+        return mailSender;
+    }
+}

--- a/src/main/java/org/example/oshipserver/global/config/RedisConfig.java
+++ b/src/main/java/org/example/oshipserver/global/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package org.example.oshipserver.global.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,7 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+@Slf4j
 @Configuration
 @EnableRedisRepositories
 public class RedisConfig {
@@ -27,6 +29,7 @@ public RedisConnectionFactory redisConnectionFactory() {
     redisStandaloneConfiguration.setHostName(host);
     redisStandaloneConfiguration.setPort(port);
 
+    log.info("connect Elastic Cache");
     return new LettuceConnectionFactory(redisStandaloneConfiguration);
 }
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,4 +1,16 @@
 spring:
+  spring:
+    mail:
+      host: ${MAIL_HOST}
+      port: ${MAIL_PORT}
+      username: ${MAIL_USERNAME}
+      password: ${MAIL_PASSWORD}  # 앱 비밀번호 16자리
+      properties:
+        mail:
+          smtp:
+            auth: true
+            starttls:
+              enable: true
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,16 +1,15 @@
 spring:
-  spring:
-    mail:
-      host: ${MAIL_HOST}
-      port: ${MAIL_PORT}
-      username: ${MAIL_USERNAME}
-      password: ${MAIL_PASSWORD}  # 앱 비밀번호 16자리
-      properties:
-        mail:
-          smtp:
-            auth: true
-            starttls:
-              enable: true
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_PORT}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}  # 앱 비밀번호 16자리
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## ✏️ Issue
Closes #113 

## ☑️ Todo
- [ ] Gmail SMTP 연동
- [ ] 알림 기능 구조 설계
- [ ] Factory 패턴으로 결제 및 배송으로 확장 설계 고려
- [ ] `EmailSender` 인터페이스 및 `GmailSmtpEmailSender` 구현체 분리 -> 운영 시 sendgrid 로 확장될 것 고려

## ✅ Test Result
![image](https://github.com/user-attachments/assets/2f2cb775-7ac1-4b43-878c-ad07ad091dc7)
![image](https://github.com/user-attachments/assets/f67ee807-69cf-4893-b9bf-76266b0cd477)

## 💌 Reviewer Notes
아직 비즈니스 로직과 연결은 안 했고,  Gmail 이 잘 들어오는지 확인만 한 상태입니다.
추후 Thymeleaf 연결해서 예쁘게 알림을 보내는 것도 고려중입니다. 
