### PR TITLE
🚑 [hotfix] #121 Gmail 알림 발송 테스트 중단

### DIFF
--- a/src/main/java/org/example/oshipserver/domain/notification/test/NotificationTest.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/test/NotificationTest.java
@@ -2,7 +2,6 @@ package org.example.oshipserver.domain.notification.test;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.oshipserver.domain.notification.dto.NotificationRequest;
 import org.example.oshipserver.domain.notification.service.EmailNotificationService;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
@@ -18,19 +17,21 @@ public class NotificationTest implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        log.info("이메일 발송 테스트 시작...");
+        // 테스트 중단
+        log.info("NotificationTest 비활성화됨 (이메일 발송 생략)");
+        return;
 
-        Long testSellerId = 1L; // 실제 이메일 연결된 sellerId
-        NotificationRequest request = new NotificationRequest(
-            "ORDER_PLACED",   // type
-            "[테스트] 주문 알림",   // title
-            "이것은 테스트 알림입니다.\n마스터 주문번호: TEST-123456", // content
-            testSellerId
-        );
-
-        // 알림 서비스 실행 (DB 저장 + 이메일 발송)
-        emailNotificationService.send(request);
-
-        log.info("테스트 이메일 발송 완료");
+        // 아래 코드는 실행되지 않음
+    /*
+    Long testSellerId = 1L;
+    NotificationRequest request = new NotificationRequest(
+        "ORDER_PLACED",
+        "[테스트] 주문 알림",
+        "이것은 테스트 알림입니다.\n마스터 주문번호: TEST-123456",
+        testSellerId
+    );
+    emailNotificationService.send(request);
+    log.info("테스트 이메일 발송 완료");
+    */
     }
 }


### PR DESCRIPTION
## ✏️ Issue
Closes #121 

## ☑️ Todo
어플리케이션 실행할때마다 Gmail 이 보내지기 때문에 해당 내용 수정합니다.

## 💌 Reviewer Notes
db에 값이 없어도 어플리케이션 실행될 것 같습니다 ~