### PR TITLE
🧠 [perf] #129 주문 생성 구조 개선 및 CPU/DB 부하 최적화

### DIFF
--- a/src/main/java/org/example/oshipserver/domain/order/controller/OrderController.java
+++ b/src/main/java/org/example/oshipserver/domain/order/controller/OrderController.java
@@ -35,14 +35,18 @@ public class OrderController {
     @OrderExecutionLog
     @PostMapping
     public ResponseEntity<BaseResponse<OrderCreateResponse>> createOrder(
+        Authentication user,
         @Valid @RequestBody OrderCreateRequest orderCreateRequest
     ) {
-        String masterNo = orderService.createOrder(orderCreateRequest);
+        Long userId = Long.valueOf(user.getName()); // 인증 정보에서 추출
+        String masterNo = orderService.createOrder(userId, orderCreateRequest);
+
         BaseResponse<OrderCreateResponse> response =
             new BaseResponse<>(201, "주문 생성이 완료되었습니다.", new OrderCreateResponse(masterNo));
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+
 
     @GetMapping
     public BaseResponse<PageResponseDto<OrderListResponse>> getOrderList(
@@ -52,11 +56,8 @@ public class OrderController {
         Pageable pageable
     ) {
         Long userId = Long.valueOf(user.getName());
-
-        PageResponseDto<OrderListResponse> response = orderService.getOrderList(userId, startDate, endDate, pageable);
-        return new BaseResponse<>(200, "주문 목록 조회 성공", response);
+        return new BaseResponse<>(200, "주문 목록 조회 성공", orderService.getOrderList(userId, startDate, endDate, pageable));
     }
-
 
     @GetMapping("/{id}")
     public BaseResponse<OrderDetailResponse> getOrderDetail(
@@ -65,26 +66,33 @@ public class OrderController {
 
     ) {
         Long userId = Long.valueOf(user.getName());
-        OrderDetailResponse response = orderService.getOrderDetail(userId, id);
-        return new BaseResponse<>(200, "주문 상세 조회 성공", response);
+        return new BaseResponse<>(200, "주문 상세 조회 성공", orderService.getOrderDetail(userId, id));
     }
 
     @PatchMapping("/{id}")
     public ResponseEntity<BaseResponse<Void>> updateOrder(
+        Authentication user,
         @PathVariable Long id,
-        @Valid @RequestBody OrderUpdateRequest request
+        @Valid @RequestBody OrderUpdateRequest orderUpdateRequest
     ) {
-        orderService.updateOrder(id, request);
+        Long userId = Long.valueOf(user.getName());
+        orderService.updateOrder(userId, id, orderUpdateRequest); // userId 전달
         return ResponseEntity.ok(new BaseResponse<>(200, "주문 정보가 수정되었습니다.", null));
     }
+
 
     /**
      * 주문 삭제 (Soft Delete)
      */
     @DeleteMapping("/{id}")
-    public BaseResponse<Void> deleteOrder(@PathVariable final Long id) {
-        orderService.softDeleteOrder(id);
+    public BaseResponse<Void> deleteOrder(
+        Authentication user,
+        @PathVariable final Long id
+    ) {
+        Long userId = Long.valueOf(user.getName());
+        orderService.softDeleteOrder(userId, id); // userId 전달
         return new BaseResponse<>(204, "주문이 성공적으로 삭제되었습니다.", null);
     }
+
 
 }

--- a/src/main/java/org/example/oshipserver/domain/order/controller/OrderExcelBulkUploadController.java
+++ b/src/main/java/org/example/oshipserver/domain/order/controller/OrderExcelBulkUploadController.java
@@ -87,9 +87,7 @@ public class OrderExcelBulkUploadController {
                 row.itemWeight(),
                 row.weightUnit(),
                 row.itemHSCode(),
-                row.itemOriginCountryCode(),
-                row.itemOriginStateCode(),
-                row.itemOriginStateName()
+                row.itemOriginCountryCode()
             )
         ).toList();
 

--- a/src/main/java/org/example/oshipserver/domain/order/controller/OrderExcelBulkUploadV3Controller.java
+++ b/src/main/java/org/example/oshipserver/domain/order/controller/OrderExcelBulkUploadV3Controller.java
@@ -87,9 +87,7 @@ public class OrderExcelBulkUploadV3Controller {
                 row.itemWeight(),
                 row.weightUnit(),
                 row.itemHSCode(),
-                row.itemOriginCountryCode(),
-                row.itemOriginStateCode(),
-                row.itemOriginStateName()
+                row.itemOriginCountryCode()
             )
         ).toList();
 

--- a/src/main/java/org/example/oshipserver/domain/order/controller/OrderExcelBulkUploadV3Controller.java
+++ b/src/main/java/org/example/oshipserver/domain/order/controller/OrderExcelBulkUploadV3Controller.java
@@ -12,7 +12,7 @@ import org.example.oshipserver.domain.order.dto.request.OrderExcelRequest;
 import org.example.oshipserver.domain.order.dto.response.OrderCreateResponse;
 import org.example.oshipserver.domain.order.entity.enums.CountryCode;
 import org.example.oshipserver.domain.order.entity.enums.StateCode;
-import org.example.oshipserver.domain.order.service.OrderBulkService;
+import org.example.oshipserver.domain.order.service.OrderBulkV3Service;
 import org.example.oshipserver.domain.order.util.ExcelOrderParser;
 import org.example.oshipserver.global.common.response.BaseResponse;
 import org.springframework.http.HttpStatus;
@@ -25,11 +25,11 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/v2/orders")
+@RequestMapping("/api/v3/orders")
 @RequiredArgsConstructor
-public class OrderExcelBulkUploadController {
+public class OrderExcelBulkUploadV3Controller {
 
-    private final OrderBulkService orderBulkService;
+    private final OrderBulkV3Service orderBulkV3Service;
     private final ExcelOrderParser excelOrderParser;
 
     /**
@@ -60,7 +60,7 @@ public class OrderExcelBulkUploadController {
             .toList();
 
         // 5. 주문 생성 처리
-        List<String> masterNos = orderBulkService.createOrdersBulk(requests);
+        List<String> masterNos = orderBulkV3Service.createOrdersBulk(requests);
         List<OrderCreateResponse> responses = masterNos.stream()
             .map(OrderCreateResponse::new)
             .toList();

--- a/src/main/java/org/example/oshipserver/domain/order/controller/OrderExcelUploadController.java
+++ b/src/main/java/org/example/oshipserver/domain/order/controller/OrderExcelUploadController.java
@@ -95,7 +95,9 @@ public class OrderExcelUploadController {
                 row.itemWeight(),
                 row.weightUnit(),
                 row.itemHSCode(),
-                row.itemOriginCountryCode()
+                row.itemOriginCountryCode(),
+                row.itemOriginStateCode(),
+                row.itemOriginStateName()
             )
         ).toList();
 
@@ -145,6 +147,7 @@ public class OrderExcelUploadController {
             base.dimensionHeight().intValue(),
             base.packageType(),
             base.shippingTerm(),
+            base.lastTrackingEvent(),
 
             // 상품 목록
             orderItems

--- a/src/main/java/org/example/oshipserver/domain/order/controller/OrderExcelUploadController.java
+++ b/src/main/java/org/example/oshipserver/domain/order/controller/OrderExcelUploadController.java
@@ -95,9 +95,7 @@ public class OrderExcelUploadController {
                 row.itemWeight(),
                 row.weightUnit(),
                 row.itemHSCode(),
-                row.itemOriginCountryCode(),
-                row.itemOriginStateCode(),
-                row.itemOriginStateName()
+                row.itemOriginCountryCode()
             )
         ).toList();
 

--- a/src/main/java/org/example/oshipserver/domain/order/controller/OrderStatsController.java
+++ b/src/main/java/org/example/oshipserver/domain/order/controller/OrderStatsController.java
@@ -2,9 +2,10 @@ package org.example.oshipserver.domain.order.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.oshipserver.domain.order.dto.response.OrderStatsResponse;
-import org.example.oshipserver.domain.order.service.OrderStatsCacheFacade;
+import org.example.oshipserver.domain.order.service.stats.OrderStatsCacheFacade;
 import org.example.oshipserver.global.common.response.BaseResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,28 +20,32 @@ public class OrderStatsController {
 
     @GetMapping("/v1/seller-stats/monthly")
     public ResponseEntity<BaseResponse<OrderStatsResponse>> getMonthlyStats(
-        @RequestParam Long sellerId,
+        Authentication authentication,
         @RequestParam String month
     ) {
-        OrderStatsResponse response = cacheFacade.getMonthlyStats(sellerId, month);
+        Long userId = Long.valueOf(authentication.getName());
+        OrderStatsResponse response = cacheFacade.getMonthlyStats(userId, month);
         return ResponseEntity.ok(new BaseResponse<>(200, "셀러 주문 통계 조회 성공", response));
     }
 
     @GetMapping("/v2/seller-stats/monthly")
     public ResponseEntity<BaseResponse<OrderStatsResponse>> getV2(
-        @RequestParam Long sellerId,
+        Authentication authentication,
         @RequestParam String month
     ) {
-        OrderStatsResponse result = cacheFacade.getMonthlyStatsV2(sellerId, month);
+        Long userId = Long.valueOf(authentication.getName());
+        OrderStatsResponse result = cacheFacade.getMonthlyStatsV2(userId, month);
         return ResponseEntity.ok(new BaseResponse<>(200, "v2 - local 캐시 통계 조회 성공", result));
     }
 
     @GetMapping("/v3/seller-stats/monthly")
     public ResponseEntity<BaseResponse<OrderStatsResponse>> getV3(
-        @RequestParam Long sellerId,
+        Authentication authentication,
         @RequestParam String month
     ) {
-        OrderStatsResponse result = cacheFacade.getMonthlyStatsV3(sellerId, month);
+        Long userId = Long.valueOf(authentication.getName());
+        OrderStatsResponse result = cacheFacade.getMonthlyStatsV3(userId, month);
         return ResponseEntity.ok(new BaseResponse<>(200, "v3 - redis 캐시 통계 조회 성공", result));
     }
 }
+

--- a/src/main/java/org/example/oshipserver/domain/order/dto/OrderItemDto.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/OrderItemDto.java
@@ -12,8 +12,6 @@ public record OrderItemDto(
     @DecimalMin("0.0") double itemWeight,
     @NotBlank String weightUnit,
     @NotBlank String itemHSCode,
-    @NotBlank String itemOriginCountryCode,
-    @NotBlank String itemOriginStateCode,
-    @NotBlank String itemOriginStateName
+    @NotBlank String itemOriginCountryCode
 ) {}
 

--- a/src/main/java/org/example/oshipserver/domain/order/dto/OrderItemDto.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/OrderItemDto.java
@@ -12,6 +12,8 @@ public record OrderItemDto(
     @DecimalMin("0.0") double itemWeight,
     @NotBlank String weightUnit,
     @NotBlank String itemHSCode,
-    @NotBlank String itemOriginCountryCode
+    @NotBlank String itemOriginCountryCode,
+    @NotBlank String itemOriginStateCode,
+    @NotBlank String itemOriginStateName
 ) {}
 

--- a/src/main/java/org/example/oshipserver/domain/order/dto/bulk/InternalOrderCreateDto.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/bulk/InternalOrderCreateDto.java
@@ -1,0 +1,8 @@
+package org.example.oshipserver.domain.order.dto.bulk;
+
+import org.example.oshipserver.domain.order.dto.request.OrderCreateRequest;
+
+public record InternalOrderCreateDto(
+    Long sellerId,
+    OrderCreateRequest request
+) {}

--- a/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderBulkDto.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderBulkDto.java
@@ -19,5 +19,6 @@ public record OrderBulkDto(
     Boolean deleted,
     LocalDateTime createdAt,
     LocalDateTime modifiedAt,
-    Long sellerId
+    Long sellerId,
+    String lastTrackingEvent
 ) {}

--- a/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderBulkDto.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderBulkDto.java
@@ -1,0 +1,23 @@
+package org.example.oshipserver.domain.order.dto.bulk;
+
+import java.time.LocalDateTime;
+
+public record OrderBulkDto(
+    String orderNo,
+    String oshipMasterNo,
+    String shippingTerm,
+    String serviceType,
+    String weightUnit,
+    Double shipmentActualWeight,
+    Double shipmentVolumeWeight,
+    Double dimensionWidth,
+    Double dimensionLength,
+    Double dimensionHeight,
+    String packageType,
+    Integer parcelCount,
+    String itemContentsType,
+    Boolean deleted,
+    LocalDateTime createdAt,
+    LocalDateTime modifiedAt,
+    Long sellerId
+) {}

--- a/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderItemBulkDto.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderItemBulkDto.java
@@ -10,8 +10,6 @@ public record OrderItemBulkDto(
     Double weight,
     String hsCode,
     String originCountryCode,
-    String originStateCode,
-    String originStateName,
     String weightUnit,
     Long orderId,// FK (orders.id 참조)
     LocalDateTime createdAt,

--- a/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderItemBulkDto.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderItemBulkDto.java
@@ -10,6 +10,8 @@ public record OrderItemBulkDto(
     Double weight,
     String hsCode,
     String originCountryCode,
+    String originStateCode,
+    String originStateName,
     String weightUnit,
     Long orderId,// FK (orders.id 참조)
     LocalDateTime createdAt,

--- a/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderItemBulkDto.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderItemBulkDto.java
@@ -1,0 +1,17 @@
+package org.example.oshipserver.domain.order.dto.bulk;
+
+import java.time.LocalDateTime;
+
+public record OrderItemBulkDto(
+    String name,
+    Integer quantity,
+    Double unitValue,
+    String valueCurrency,
+    Double weight,
+    String hsCode,
+    String originCountryCode,
+    String weightUnit,
+    Long orderId,// FK (orders.id 참조)
+    LocalDateTime createdAt,
+    LocalDateTime modifiedAt
+) {}

--- a/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderRecipientBulkDto.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderRecipientBulkDto.java
@@ -1,0 +1,10 @@
+package org.example.oshipserver.domain.order.dto.bulk;
+
+public record OrderRecipientBulkDto(
+    Long orderId,                  // FK: orders.id
+    Long recipientAddressId,       // FK: recipient_addresses.id
+    String recipientCompany,
+    String recipientEmail,
+    String recipientName,
+    String recipientPhoneNo
+) {}

--- a/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderSenderBulkDto.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/bulk/OrderSenderBulkDto.java
@@ -1,0 +1,13 @@
+package org.example.oshipserver.domain.order.dto.bulk;
+
+public record OrderSenderBulkDto(
+    Long orderId,              // FK: orders.id
+    Long sellerId,             // Nullable
+    Long senderAddressId,      // FK: sender_addresses.id
+    String senderCompany,
+    String senderEmail,
+    String senderName,
+    String senderPhoneNo,
+    String storeName,
+    String storePlatform
+) {}

--- a/src/main/java/org/example/oshipserver/domain/order/dto/bulk/RecipientAddressBulkDto.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/bulk/RecipientAddressBulkDto.java
@@ -1,0 +1,13 @@
+package org.example.oshipserver.domain.order.dto.bulk;
+
+public record RecipientAddressBulkDto(
+    String oshipMasterNo,               // 임시 연결용 키 (order, address 매핑용)
+    String recipientAddress1,
+    String recipientAddress2,
+    String recipientCity,
+    String recipientState,
+    String recipientStateCode,
+    String recipientTaxId,
+    String recipientZipCode,
+    String recipientCountryCode
+) {}

--- a/src/main/java/org/example/oshipserver/domain/order/dto/bulk/SenderAddressBulkDto.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/bulk/SenderAddressBulkDto.java
@@ -1,0 +1,13 @@
+package org.example.oshipserver.domain.order.dto.bulk;
+
+public record SenderAddressBulkDto(
+    String oshipMasterNo,          // 임시 키, orderId 매핑 전 기준
+    String senderAddress1,
+    String senderAddress2,
+    String senderCity,
+    String senderState,
+    String senderStateCode,
+    String senderTaxId,
+    String senderZipCode,
+    String senderCountryCode
+) {}

--- a/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderCreateRequest.java
@@ -61,6 +61,7 @@ public record OrderCreateRequest(
     @Min(1) int dimensionHeight,
     @NotBlank String packageType,
     @NotBlank String shippingTerm,
+    String lastTrackingEvent,
 
     @NotEmpty List<@Valid OrderItemDto> orderItems
 ) {}

--- a/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderCreateRequest.java
@@ -61,7 +61,6 @@ public record OrderCreateRequest(
     @Min(1) int dimensionHeight,
     @NotBlank String packageType,
     @NotBlank String shippingTerm,
-    @NotNull Long sellerId,
 
     @NotEmpty List<@Valid OrderItemDto> orderItems
 ) {}

--- a/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderDeleteRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderDeleteRequest.java
@@ -1,9 +1,0 @@
-package org.example.oshipserver.domain.order.dto.request;
-
-import jakarta.validation.constraints.NotNull;
-import org.example.oshipserver.domain.order.entity.enums.DeleterRole;
-
-public record OrderDeleteRequest(
-    @NotNull(message = "삭제 주체는 필수입니다.")
-    DeleterRole deletedBy
-) {}

--- a/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderExcelRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderExcelRequest.java
@@ -50,8 +50,6 @@ public record OrderExcelRequest(
     Double itemWeight,
     String itemHSCode,
     String itemOriginCountryCode,
-    String itemOriginStateCode,
-    String itemOriginStateName,
     String lastTrackingEvent
 ) {
     public static OrderExcelRequest from(Row row) {
@@ -64,8 +62,8 @@ public record OrderExcelRequest(
             getString(row, 24), getString(row, 25), getDouble(row, 26), getDouble(row, 27), getString(row, 28),
             getDouble(row, 29), getDouble(row, 30), getDouble(row, 31), getString(row, 32), getInt(row, 33),
             getString(row, 34), getString(row, 35), getString(row, 36), getInt(row, 37), getDouble(row, 38),
-            getString(row, 39), getDouble(row, 40), getString(row, 41), getString(row, 42),getString(row, 43),
-            getString(row, 44),getString(row, 45)
+            getString(row, 39), getDouble(row, 40), getString(row, 41), getString(row, 42),getString(row, 43)
+
         );
     }
 

--- a/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderExcelRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderExcelRequest.java
@@ -10,7 +10,6 @@ public record OrderExcelRequest(
     String storePlatform,
     String storeName,
     String orderNo,
-    String sellerId,
     String shippingTerm,
     String senderName,
     String senderCompany,
@@ -54,15 +53,16 @@ public record OrderExcelRequest(
 ) {
     public static OrderExcelRequest from(Row row) {
         return new OrderExcelRequest(
-            getString(row, 0), getString(row, 1), getString(row, 2), getString(row, 3), getString(row, 4),
-            getString(row, 5), getString(row, 6), getString(row, 7), getString(row, 8), getString(row, 9),
-            getString(row, 10), getString(row, 11), getString(row, 12), getString(row, 13), getString(row, 14),
-            getString(row, 15), getString(row, 16), getString(row, 17), getString(row, 18), getString(row, 19),
-            getString(row, 20), getString(row, 21), getString(row, 22), getString(row, 23), getString(row, 24),
-            getString(row, 25), getString(row, 26), getDouble(row, 27), getDouble(row, 28), getString(row, 29),
-            getDouble(row, 30), getDouble(row, 31), getDouble(row, 32), getString(row, 33), getInt(row, 34),
-            getString(row, 35), getString(row, 36), getString(row, 37), getInt(row, 38), getDouble(row, 39),
-            getString(row, 40), getDouble(row, 41), getString(row, 42), getString(row, 43)
+            getString(row, 0), getString(row, 1), getString(row, 2), getString(row, 3),
+            getString(row, 4), getString(row, 5), getString(row, 6), getString(row, 7), getString(row, 8),
+            getString(row, 9), getString(row, 10), getString(row, 11), getString(row, 12), getString(row, 13),
+            getString(row, 14), getString(row, 15), getString(row, 16), getString(row, 17), getString(row, 18),
+            getString(row, 19), getString(row, 20), getString(row, 21), getString(row, 22), getString(row, 23),
+            getString(row, 24), getString(row, 25), getDouble(row, 26), getDouble(row, 27), getString(row, 28),
+            getDouble(row, 29), getDouble(row, 30), getDouble(row, 31), getString(row, 32), getInt(row, 33),
+            getString(row, 34), getString(row, 35), getString(row, 36), getInt(row, 37), getDouble(row, 38),
+            getString(row, 39), getDouble(row, 40), getString(row, 41), getString(row, 42)
         );
     }
+
 }

--- a/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderExcelRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderExcelRequest.java
@@ -49,7 +49,10 @@ public record OrderExcelRequest(
     String itemValueCurrency,
     Double itemWeight,
     String itemHSCode,
-    String itemOriginCountryCode
+    String itemOriginCountryCode,
+    String itemOriginStateCode,
+    String itemOriginStateName,
+    String lastTrackingEvent
 ) {
     public static OrderExcelRequest from(Row row) {
         return new OrderExcelRequest(
@@ -61,7 +64,8 @@ public record OrderExcelRequest(
             getString(row, 24), getString(row, 25), getDouble(row, 26), getDouble(row, 27), getString(row, 28),
             getDouble(row, 29), getDouble(row, 30), getDouble(row, 31), getString(row, 32), getInt(row, 33),
             getString(row, 34), getString(row, 35), getString(row, 36), getInt(row, 37), getDouble(row, 38),
-            getString(row, 39), getDouble(row, 40), getString(row, 41), getString(row, 42)
+            getString(row, 39), getDouble(row, 40), getString(row, 41), getString(row, 42),getString(row, 43),
+            getString(row, 44),getString(row, 45)
         );
     }
 

--- a/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderItemRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderItemRequest.java
@@ -15,7 +15,9 @@ public record OrderItemRequest(
     @DecimalMin("0.0") double itemWeight,
     @NotBlank String weightUnit,
     @NotBlank String itemHSCode,
-    @NotBlank String itemOriginCountryCode
+    @NotBlank String itemOriginCountryCode,
+    @NotBlank String itemOriginStateCode,
+    @NotBlank String itemOriginStateName
 ) {
     public OrderItem toEntity() {
         return OrderItem.builder()
@@ -27,6 +29,8 @@ public record OrderItemRequest(
             .weightUnit(weightUnit)
             .hsCode(itemHSCode)
             .originCountryCode(itemOriginCountryCode)
+            .itemOriginStateCode(itemOriginStateCode)
+            .itemOriginStateName(itemOriginStateName)
             .build();
     }
 }

--- a/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderItemRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/request/OrderItemRequest.java
@@ -15,9 +15,8 @@ public record OrderItemRequest(
     @DecimalMin("0.0") double itemWeight,
     @NotBlank String weightUnit,
     @NotBlank String itemHSCode,
-    @NotBlank String itemOriginCountryCode,
-    @NotBlank String itemOriginStateCode,
-    @NotBlank String itemOriginStateName
+    @NotBlank String itemOriginCountryCode
+
 ) {
     public OrderItem toEntity() {
         return OrderItem.builder()
@@ -29,8 +28,6 @@ public record OrderItemRequest(
             .weightUnit(weightUnit)
             .hsCode(itemHSCode)
             .originCountryCode(itemOriginCountryCode)
-            .itemOriginStateCode(itemOriginStateCode)
-            .itemOriginStateName(itemOriginStateName)
             .build();
     }
 }

--- a/src/main/java/org/example/oshipserver/domain/order/dto/response/OrderDetailResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/response/OrderDetailResponse.java
@@ -104,7 +104,10 @@ public record OrderDetailResponse(
                 new Address(
                     order.getSender().getSenderAddress().getSenderCountryCode().name(),
                     order.getSender().getSenderAddress().getSenderState(),
-                    order.getSender().getSenderAddress().getSenderStateCode().name(),
+                    //  null-safe 처리 추가
+                    order.getSender().getSenderAddress().getSenderStateCode() != null
+                        ? order.getSender().getSenderAddress().getSenderStateCode().name()
+                        : null,
                     order.getSender().getSenderAddress().getSenderCity(),
                     order.getSender().getSenderAddress().getSenderAddress1(),
                     order.getSender().getSenderAddress().getSenderAddress2(),
@@ -120,7 +123,10 @@ public record OrderDetailResponse(
                 new Address(
                     order.getRecipient().getRecipientAddress().getRecipientCountryCode().name(),
                     order.getRecipient().getRecipientAddress().getRecipientState(),
-                    order.getRecipient().getRecipientAddress().getRecipientStateCode().name(),
+                    // null 처리 추가
+                    order.getRecipient().getRecipientAddress().getRecipientStateCode() != null
+                        ? order.getRecipient().getRecipientAddress().getRecipientStateCode().name()
+                        : null,
                     order.getRecipient().getRecipientAddress().getRecipientCity(),
                     order.getRecipient().getRecipientAddress().getRecipientAddress1(),
                     order.getRecipient().getRecipientAddress().getRecipientAddress2(),

--- a/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
@@ -48,7 +48,7 @@ public class Order extends BaseTimeEntity {
     private String orderNo;
 
     // 수량 및 중량
-    private int parcelCount;
+    private Integer parcelCount;
     private BigDecimal shipmentActualWeight;
     private BigDecimal shipmentVolumeWeight;
     private String weightUnit;
@@ -62,7 +62,7 @@ public class Order extends BaseTimeEntity {
     private LocalDateTime deletedAt;
 
     // 상태
-    private boolean deleted = false;
+    private Boolean deleted = false;
 
     @Enumerated(EnumType.STRING)
     @CreatedBy // 삭제 주체 자동 주입
@@ -116,13 +116,13 @@ public class Order extends BaseTimeEntity {
         String orderNo,
         String oshipMasterNo,
         String weightUnit,
-        int parcelCount,
+        Integer parcelCount,
         BigDecimal shipmentActualWeight,
         BigDecimal shipmentVolumeWeight,
         BigDecimal dimensionWidth,
         BigDecimal dimensionHeight,
         BigDecimal dimensionLength,
-        boolean deleted,
+        Boolean deleted,
         OrderStatus currentStatus,
         String itemContentsType,
         String serviceType,

--- a/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
@@ -156,7 +156,7 @@ public class Order extends BaseTimeEntity {
      * @param dto      주문 요청 DTO
      * @param masterNo 외부 식별자
      */
-    public static Order of(OrderCreateRequest dto, String masterNo) {
+    public static Order of(OrderCreateRequest dto, String masterNo, Long userId) {
         return Order.builder()
             .orderNo(dto.orderNo())
             .oshipMasterNo(masterNo)
@@ -173,9 +173,10 @@ public class Order extends BaseTimeEntity {
             .serviceType(dto.serviceType())
             .packageType(dto.packageType())
             .shippingTerm(dto.shippingTerm())
-            .sellerId(dto.sellerId())
+            .sellerId(userId)
             .build();
     }
+
 
     /**
      * 주문 상품 목록 추가

--- a/src/main/java/org/example/oshipserver/domain/order/entity/OrderItem.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/OrderItem.java
@@ -35,8 +35,6 @@ public class OrderItem extends BaseTimeEntity {
     private BigDecimal weight;
     private String hsCode;
     private String originCountryCode;
-    private String  itemOriginStateCode;
-    private String itemOriginStateName;
 
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -46,8 +44,8 @@ public class OrderItem extends BaseTimeEntity {
     @Builder
     private OrderItem(
         String name, int quantity, BigDecimal unitValue, String valueCurrency,
-        BigDecimal weight, String weightUnit, String hsCode, String originCountryCode,
-        String itemOriginStateCode, String itemOriginStateName
+        BigDecimal weight, String weightUnit, String hsCode, String originCountryCode
+
     ) {
         this.name = name;
         this.quantity = quantity;
@@ -57,8 +55,6 @@ public class OrderItem extends BaseTimeEntity {
         this.weightUnit = weightUnit;
         this.hsCode = hsCode;
         this.originCountryCode = originCountryCode;
-        this.itemOriginStateCode = itemOriginStateCode;
-        this.itemOriginStateName = itemOriginStateName;
     }
 
     public static OrderItem of(OrderItemDto dto) {
@@ -71,8 +67,6 @@ public class OrderItem extends BaseTimeEntity {
             .weightUnit(dto.weightUnit())
             .hsCode(dto.itemHSCode())
             .originCountryCode(dto.itemOriginCountryCode())
-            .itemOriginStateCode(dto.itemOriginStateCode())
-            .itemOriginStateName(dto.itemOriginStateName())
             .build();
     }
 
@@ -86,8 +80,6 @@ public class OrderItem extends BaseTimeEntity {
         this.weightUnit = req.weightUnit();
         this.hsCode = req.itemHSCode();
         this.originCountryCode = req.itemOriginCountryCode();
-        this.itemOriginStateCode = req.itemOriginStateCode();
-        this.itemOriginStateName = req.itemOriginStateName();
     }
 
     /**

--- a/src/main/java/org/example/oshipserver/domain/order/entity/OrderItem.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/OrderItem.java
@@ -35,6 +35,9 @@ public class OrderItem extends BaseTimeEntity {
     private BigDecimal weight;
     private String hsCode;
     private String originCountryCode;
+    private String  itemOriginStateCode;
+    private String itemOriginStateName;
+
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id")
@@ -43,7 +46,8 @@ public class OrderItem extends BaseTimeEntity {
     @Builder
     private OrderItem(
         String name, int quantity, BigDecimal unitValue, String valueCurrency,
-        BigDecimal weight, String weightUnit, String hsCode, String originCountryCode
+        BigDecimal weight, String weightUnit, String hsCode, String originCountryCode,
+        String itemOriginStateCode, String itemOriginStateName
     ) {
         this.name = name;
         this.quantity = quantity;
@@ -53,6 +57,8 @@ public class OrderItem extends BaseTimeEntity {
         this.weightUnit = weightUnit;
         this.hsCode = hsCode;
         this.originCountryCode = originCountryCode;
+        this.itemOriginStateCode = itemOriginStateCode;
+        this.itemOriginStateName = itemOriginStateName;
     }
 
     public static OrderItem of(OrderItemDto dto) {
@@ -65,6 +71,8 @@ public class OrderItem extends BaseTimeEntity {
             .weightUnit(dto.weightUnit())
             .hsCode(dto.itemHSCode())
             .originCountryCode(dto.itemOriginCountryCode())
+            .itemOriginStateCode(dto.itemOriginStateCode())
+            .itemOriginStateName(dto.itemOriginStateName())
             .build();
     }
 
@@ -78,6 +86,8 @@ public class OrderItem extends BaseTimeEntity {
         this.weightUnit = req.weightUnit();
         this.hsCode = req.itemHSCode();
         this.originCountryCode = req.itemOriginCountryCode();
+        this.itemOriginStateCode = req.itemOriginStateCode();
+        this.itemOriginStateName = req.itemOriginStateName();
     }
 
     /**

--- a/src/main/java/org/example/oshipserver/domain/order/entity/OrderSender.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/OrderSender.java
@@ -47,6 +47,7 @@ public class OrderSender {
     private SenderAddress senderAddress;
 
     public void assignOrder(Order order) {
+        this.sellerId = order.getSellerId();
         this.order = order;
     }
 

--- a/src/main/java/org/example/oshipserver/domain/order/repository/IOrderRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/order/repository/IOrderRepository.java
@@ -1,0 +1,8 @@
+package org.example.oshipserver.domain.order.repository;
+
+import java.util.List;
+
+public interface IOrderRepository {
+    List<String> findExistingOrderNos(Long sellerId, List<String> orderNos);
+
+}

--- a/src/main/java/org/example/oshipserver/domain/order/repository/IOrderRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/order/repository/IOrderRepository.java
@@ -5,4 +5,6 @@ import java.util.List;
 public interface IOrderRepository {
     List<String> findExistingOrderNos(Long sellerId, List<String> orderNos);
 
+    List<String> findExistingMasterNos(List<String> masterNos);
+
 }

--- a/src/main/java/org/example/oshipserver/domain/order/repository/IOrderRepositoryImpl.java
+++ b/src/main/java/org/example/oshipserver/domain/order/repository/IOrderRepositoryImpl.java
@@ -1,0 +1,30 @@
+package org.example.oshipserver.domain.order.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.oshipserver.domain.order.entity.QOrder;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class IOrderRepositoryImpl implements IOrderRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final QOrder order = QOrder.order;
+
+    @Override
+    public List<String> findExistingOrderNos(Long sellerId, List<String> orderNos) {
+        return queryFactory
+            .select(order.orderNo)
+            .from(order)
+            .where(order.sellerId.eq(sellerId)
+                .and(order.orderNo.in(orderNos)))
+            .fetch();
+    }
+
+
+}

--- a/src/main/java/org/example/oshipserver/domain/order/repository/IOrderRepositoryImpl.java
+++ b/src/main/java/org/example/oshipserver/domain/order/repository/IOrderRepositoryImpl.java
@@ -26,5 +26,13 @@ public class IOrderRepositoryImpl implements IOrderRepository {
             .fetch();
     }
 
+    @Override
+    public List<String> findExistingMasterNos(List<String> masterNos) {
+        return queryFactory
+            .select(order.oshipMasterNo)
+            .from(order)
+            .where(order.oshipMasterNo.in(masterNos))
+            .fetch();
+    }
 
 }

--- a/src/main/java/org/example/oshipserver/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/order/repository/OrderRepository.java
@@ -15,8 +15,6 @@ import org.springframework.stereotype.Repository;
 public interface OrderRepository extends JpaRepository<Order,Long> {
     boolean existsByOrderNoAndSellerId(String orderNo, Long sellerId);
     boolean existsByOshipMasterNo(String masterNo);
-    Page<Order> findByCreatedAtBetweenAndDeletedFalse(
-        LocalDateTime start, LocalDateTime end, Pageable pageable);
 
     Page<Order> findBySellerIdAndCreatedAtBetweenAndDeletedFalse(
         Long sellerId, LocalDateTime start, LocalDateTime end, Pageable pageable);

--- a/src/main/java/org/example/oshipserver/domain/order/repository/jdbc/IOrderJdbcRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/order/repository/jdbc/IOrderJdbcRepository.java
@@ -1,0 +1,25 @@
+package org.example.oshipserver.domain.order.repository.jdbc;
+
+import java.util.List;
+import java.util.Map;
+import org.example.oshipserver.domain.order.dto.bulk.OrderBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.OrderItemBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.OrderRecipientBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.OrderSenderBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.RecipientAddressBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.SenderAddressBulkDto;
+
+public interface IOrderJdbcRepository {
+    void bulkInsertOrders(List<OrderBulkDto> orders);
+    void bulkInsertOrderItems(List<OrderItemBulkDto> items);
+    void bulkInsertOrderSenders(List<OrderSenderBulkDto> senders);
+    void bulkInsertOrderRecipients(List<OrderRecipientBulkDto> recipients);
+    void bulkInsertSenderAddresses(List<SenderAddressBulkDto> addresses);
+    void bulkInsertRecipientAddresses(List<RecipientAddressBulkDto> addresses);
+    Map<String, Long> findOrderIdMapByMasterNos(List<String> masterNos);
+
+    Map<String, Long> findSenderAddressIdsByMasterNos(List<String> masterNos);
+    Map<String, Long> findRecipientAddressIdsByMasterNos(List<String> masterNos);
+
+
+}

--- a/src/main/java/org/example/oshipserver/domain/order/repository/jdbc/IOrderJdbcRepositoryImpl.java
+++ b/src/main/java/org/example/oshipserver/domain/order/repository/jdbc/IOrderJdbcRepositoryImpl.java
@@ -44,8 +44,8 @@ public class IOrderJdbcRepositoryImpl implements IOrderJdbcRepository {
     public void bulkInsertOrders(List<OrderBulkDto> orders) {
         String sql = "INSERT INTO orders (order_no, oship_master_no, shipping_term, service_type, weight_unit, " +
             "shipment_actual_weight, shipment_volume_weight, dimension_width, dimension_length, dimension_height, " +
-            "package_type, parcel_count, item_contents_type, deleted, created_at, modified_at, seller_id) " +
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            "package_type, parcel_count, item_contents_type, deleted, created_at, modified_at, seller_id,last_tracking_event) " +
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
         jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
             @Override
@@ -71,6 +71,7 @@ public class IOrderJdbcRepositoryImpl implements IOrderJdbcRepository {
                 ps.setTimestamp(15, toTimestamp(o.createdAt()));
                 ps.setTimestamp(16, toTimestamp(o.modifiedAt()));
                 ps.setObject(17, o.sellerId());
+                ps.setString(18, o.lastTrackingEvent());
             }
 
             @Override
@@ -139,9 +140,9 @@ public class IOrderJdbcRepositoryImpl implements IOrderJdbcRepository {
     public void bulkInsertOrderItems(List<OrderItemBulkDto> items) {
         String sql = "INSERT INTO order_items (" +
             "name, quantity, unit_value, value_currency, " +
-            "weight, hs_code, origin_country_code, weight_unit, " +
+            "weight, hs_code, origin_country_code, item_origin_state_code, item_origin_state_name, weight_unit, " +
             "order_id, created_at, modified_at" +
-            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
         jdbcTemplate.batchUpdate(sql, items, 1000, (ps, item) -> {
             ps.setString(1, item.name());
@@ -151,12 +152,15 @@ public class IOrderJdbcRepositoryImpl implements IOrderJdbcRepository {
             setDoubleOrNull(ps, 5, item.weight());
             ps.setString(6, item.hsCode());
             ps.setString(7, item.originCountryCode());
-            ps.setString(8, item.weightUnit());
-            setLongOrNull(ps, 9, item.orderId());
-            ps.setTimestamp(10, toTimestamp(item.createdAt()));
-            ps.setTimestamp(11, toTimestamp(item.modifiedAt()));
+            ps.setString(8, item.originStateCode());
+            ps.setString(9, item.originStateName());
+            ps.setString(10, item.weightUnit());
+            setLongOrNull(ps, 11, item.orderId());
+            ps.setTimestamp(12, toTimestamp(item.createdAt()));
+            ps.setTimestamp(13, toTimestamp(item.modifiedAt()));
         });
     }
+
 
     @Override
     public void bulkInsertOrderSenders(List<OrderSenderBulkDto> senders) {

--- a/src/main/java/org/example/oshipserver/domain/order/repository/jdbc/IOrderJdbcRepositoryImpl.java
+++ b/src/main/java/org/example/oshipserver/domain/order/repository/jdbc/IOrderJdbcRepositoryImpl.java
@@ -140,9 +140,9 @@ public class IOrderJdbcRepositoryImpl implements IOrderJdbcRepository {
     public void bulkInsertOrderItems(List<OrderItemBulkDto> items) {
         String sql = "INSERT INTO order_items (" +
             "name, quantity, unit_value, value_currency, " +
-            "weight, hs_code, origin_country_code, item_origin_state_code, item_origin_state_name, weight_unit, " +
+            "weight, hs_code, origin_country_code, weight_unit, " +
             "order_id, created_at, modified_at" +
-            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
         jdbcTemplate.batchUpdate(sql, items, 1000, (ps, item) -> {
             ps.setString(1, item.name());
@@ -152,14 +152,13 @@ public class IOrderJdbcRepositoryImpl implements IOrderJdbcRepository {
             setDoubleOrNull(ps, 5, item.weight());
             ps.setString(6, item.hsCode());
             ps.setString(7, item.originCountryCode());
-            ps.setString(8, item.originStateCode());
-            ps.setString(9, item.originStateName());
-            ps.setString(10, item.weightUnit());
-            setLongOrNull(ps, 11, item.orderId());
-            ps.setTimestamp(12, toTimestamp(item.createdAt()));
-            ps.setTimestamp(13, toTimestamp(item.modifiedAt()));
+            ps.setString(8, item.weightUnit());
+            setLongOrNull(ps, 9, item.orderId());
+            ps.setTimestamp(10, toTimestamp(item.createdAt()));
+            ps.setTimestamp(11, toTimestamp(item.modifiedAt()));
         });
     }
+
 
 
     @Override

--- a/src/main/java/org/example/oshipserver/domain/order/repository/jdbc/IOrderJdbcRepositoryImpl.java
+++ b/src/main/java/org/example/oshipserver/domain/order/repository/jdbc/IOrderJdbcRepositoryImpl.java
@@ -1,0 +1,249 @@
+package org.example.oshipserver.domain.order.repository.jdbc;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.oshipserver.domain.order.dto.bulk.*;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Slf4j
+@RequiredArgsConstructor
+public class IOrderJdbcRepositoryImpl implements IOrderJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    @Override
+    public Map<String, Long> findOrderIdMapByMasterNos(List<String> masterNos) {
+        if (masterNos == null || masterNos.isEmpty()) return Map.of();
+
+        String sql = "SELECT oship_master_no, id FROM orders WHERE oship_master_no IN (:masterNos)";
+        MapSqlParameterSource parameters = new MapSqlParameterSource("masterNos", masterNos);
+
+        return namedParameterJdbcTemplate.query(sql, parameters, rs -> {
+            Map<String, Long> result = new HashMap<>();
+            while (rs.next()) {
+                result.put(rs.getString("oship_master_no"), rs.getLong("id"));
+            }
+            return result;
+        });
+    }
+
+    @Override
+    public void bulkInsertOrders(List<OrderBulkDto> orders) {
+        String sql = "INSERT INTO orders (order_no, oship_master_no, shipping_term, service_type, weight_unit, " +
+            "shipment_actual_weight, shipment_volume_weight, dimension_width, dimension_length, dimension_height, " +
+            "package_type, parcel_count, item_contents_type, deleted, created_at, modified_at, seller_id) " +
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                OrderBulkDto o = orders.get(i);
+                log.info("[ORDER INSERT] [{}] orderNo={}, deleted={}, createdAt={}, modifiedAt={}",
+                    i, o.orderNo(), o.deleted(), o.createdAt(), o.modifiedAt());
+
+                ps.setString(1, o.orderNo());
+                ps.setString(2, o.oshipMasterNo());
+                ps.setString(3, o.shippingTerm());
+                ps.setString(4, o.serviceType());
+                ps.setString(5, o.weightUnit());
+                setDoubleOrNull(ps, 6, o.shipmentActualWeight());
+                setDoubleOrNull(ps, 7, o.shipmentVolumeWeight());
+                setDoubleOrNull(ps, 8, o.dimensionWidth());
+                setDoubleOrNull(ps, 9, o.dimensionLength());
+                setDoubleOrNull(ps, 10, o.dimensionHeight());
+                ps.setString(11, o.packageType());
+                setIntOrNull(ps, 12, o.parcelCount());
+                ps.setString(13, o.itemContentsType());
+                ps.setByte(14, (byte) (Boolean.TRUE.equals(o.deleted()) ? 1 : 0));
+                ps.setTimestamp(15, toTimestamp(o.createdAt()));
+                ps.setTimestamp(16, toTimestamp(o.modifiedAt()));
+                ps.setObject(17, o.sellerId());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return orders.size();
+            }
+        });
+    }
+
+    private Timestamp toTimestamp(LocalDateTime time) {
+        return (time != null)
+            ? Timestamp.valueOf(time.withNano((time.getNano() / 1_000_000) * 1_000_000))
+            : new Timestamp(System.currentTimeMillis());
+    }
+
+    private void setDoubleOrNull(PreparedStatement ps, int index, Double value) throws SQLException {
+        if (value != null) ps.setDouble(index, value);
+        else ps.setNull(index, java.sql.Types.DOUBLE);
+    }
+
+    private void setIntOrNull(PreparedStatement ps, int index, Integer value) throws SQLException {
+        if (value != null) ps.setInt(index, value);
+        else ps.setNull(index, java.sql.Types.INTEGER);
+    }
+
+    private void setLongOrNull(PreparedStatement ps, int index, Long value) throws SQLException {
+        if (value != null) ps.setLong(index, value);
+        else ps.setNull(index, java.sql.Types.BIGINT);
+    }
+
+    @Override
+    public Map<String, Long> findSenderAddressIdsByMasterNos(List<String> masterNos) {
+        if (masterNos == null || masterNos.isEmpty()) return Map.of();
+
+        String sql = "SELECT id FROM sender_addresses ORDER BY id DESC LIMIT :size";
+        MapSqlParameterSource parameters = new MapSqlParameterSource("size", masterNos.size());
+
+        return namedParameterJdbcTemplate.query(sql, parameters, rs -> {
+            Map<String, Long> result = new HashMap<>();
+            int index = 0;
+            while (rs.next() && index < masterNos.size()) {
+                result.put(masterNos.get(index++), rs.getLong("id"));
+            }
+            return result;
+        });
+    }
+
+    @Override
+    public Map<String, Long> findRecipientAddressIdsByMasterNos(List<String> masterNos) {
+        if (masterNos == null || masterNos.isEmpty()) return Map.of();
+
+        String sql = "SELECT id FROM recipient_addresses ORDER BY id DESC LIMIT :size";
+        MapSqlParameterSource parameters = new MapSqlParameterSource("size", masterNos.size());
+
+        return namedParameterJdbcTemplate.query(sql, parameters, rs -> {
+            Map<String, Long> result = new HashMap<>();
+            int index = 0;
+            while (rs.next() && index < masterNos.size()) {
+                result.put(masterNos.get(index++), rs.getLong("id"));
+            }
+            return result;
+        });
+    }
+
+    @Override
+    public void bulkInsertOrderItems(List<OrderItemBulkDto> items) {
+        String sql = "INSERT INTO order_items (" +
+            "name, quantity, unit_value, value_currency, " +
+            "weight, hs_code, origin_country_code, weight_unit, " +
+            "order_id, created_at, modified_at" +
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(sql, items, 1000, (ps, item) -> {
+            ps.setString(1, item.name());
+            setIntOrNull(ps, 2, item.quantity());
+            setDoubleOrNull(ps, 3, item.unitValue());
+            ps.setString(4, item.valueCurrency());
+            setDoubleOrNull(ps, 5, item.weight());
+            ps.setString(6, item.hsCode());
+            ps.setString(7, item.originCountryCode());
+            ps.setString(8, item.weightUnit());
+            setLongOrNull(ps, 9, item.orderId());
+            ps.setTimestamp(10, toTimestamp(item.createdAt()));
+            ps.setTimestamp(11, toTimestamp(item.modifiedAt()));
+        });
+    }
+
+    @Override
+    public void bulkInsertOrderSenders(List<OrderSenderBulkDto> senders) {
+        String sql = """
+            INSERT INTO order_senders (
+                order_id, seller_id, sender_address_id,
+                sender_company, sender_email, sender_name, sender_phone_no,
+                store_name, store_platform
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+
+        jdbcTemplate.batchUpdate(sql, senders, 1000, (ps, s) -> {
+            ps.setObject(1, s.orderId());
+            ps.setObject(2, s.sellerId());
+            ps.setObject(3, s.senderAddressId());
+            ps.setString(4, s.senderCompany());
+            ps.setString(5, s.senderEmail());
+            ps.setString(6, s.senderName());
+            ps.setString(7, s.senderPhoneNo());
+            ps.setString(8, s.storeName());
+            ps.setString(9, s.storePlatform());
+        });
+    }
+
+    @Override
+    public void bulkInsertOrderRecipients(List<OrderRecipientBulkDto> recipients) {
+        String sql = """
+            INSERT INTO order_recipients (
+                order_id,
+                recipient_address_id,
+                recipient_company,
+                recipient_email,
+                recipient_name,
+                recipient_phone_no
+            ) VALUES (?, ?, ?, ?, ?, ?)
+        """;
+
+        jdbcTemplate.batchUpdate(sql, recipients, 1000, (ps, r) -> {
+            ps.setObject(1, r.orderId());
+            ps.setObject(2, r.recipientAddressId());
+            ps.setString(3, r.recipientCompany());
+            ps.setString(4, r.recipientEmail());
+            ps.setString(5, r.recipientName());
+            ps.setString(6, r.recipientPhoneNo());
+        });
+    }
+
+    @Override
+    public void bulkInsertSenderAddresses(List<SenderAddressBulkDto> addresses) {
+        String sql = """
+            INSERT INTO sender_addresses (
+                sender_address_1, sender_address_2, sender_city, sender_state,
+                sender_state_code, sender_tax_id, sender_zip_code, sender_country_code
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+
+        jdbcTemplate.batchUpdate(sql, addresses, 1000, (ps, addr) -> {
+            ps.setString(1, addr.senderAddress1());
+            ps.setString(2, addr.senderAddress2());
+            ps.setString(3, addr.senderCity());
+            ps.setString(4, addr.senderState());
+            ps.setString(5, addr.senderStateCode());
+            ps.setString(6, addr.senderTaxId());
+            ps.setString(7, addr.senderZipCode());
+            ps.setString(8, addr.senderCountryCode());
+        });
+    }
+
+    @Override
+    public void bulkInsertRecipientAddresses(List<RecipientAddressBulkDto> addresses) {
+        String sql = """
+            INSERT INTO recipient_addresses (
+                recipient_address_1, recipient_address_2, recipient_city, recipient_state,
+                recipient_state_code, recipient_tax_id, recipient_zip_code, recipient_country_code
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+
+        jdbcTemplate.batchUpdate(sql, addresses, 1000, (ps, addr) -> {
+            ps.setString(1, addr.recipientAddress1());
+            ps.setString(2, addr.recipientAddress2());
+            ps.setString(3, addr.recipientCity());
+            ps.setString(4, addr.recipientState());
+            ps.setString(5, addr.recipientStateCode());
+            ps.setString(6, addr.recipientTaxId());
+            ps.setString(7, addr.recipientZipCode());
+            ps.setString(8, addr.recipientCountryCode());
+        });
+    }
+
+}

--- a/src/main/java/org/example/oshipserver/domain/order/service/OrderBulkService.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/OrderBulkService.java
@@ -1,0 +1,136 @@
+package org.example.oshipserver.domain.order.service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.oshipserver.domain.order.dto.bulk.InternalOrderCreateDto;
+import org.example.oshipserver.domain.order.dto.bulk.OrderBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.OrderItemBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.OrderRecipientBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.OrderSenderBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.RecipientAddressBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.SenderAddressBulkDto;
+import org.example.oshipserver.domain.order.dto.request.OrderCreateRequest;
+import org.example.oshipserver.domain.order.repository.IOrderRepository;
+import org.example.oshipserver.domain.order.repository.jdbc.IOrderJdbcRepository;
+import org.example.oshipserver.domain.order.service.bulkmapper.OrderDtoMapper;
+import org.example.oshipserver.global.exception.ApiException;
+import org.example.oshipserver.global.exception.ErrorType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderBulkService {
+
+    private final IOrderRepository orderRepository;
+    private final IOrderJdbcRepository orderJdbcRepository;
+    private final OrderDtoMapper orderDtoMapper;
+    private final OrderService orderService;
+
+    @Transactional
+    public List<String> createOrdersBulk(List<InternalOrderCreateDto> requests) {
+
+        // 1. 주문번호 중복 확인
+        Set<String> incomingOrderNos = requests.stream()
+            .map(dto -> dto.request().orderNo())
+            .collect(Collectors.toSet());
+
+        Long sellerId = requests.get(0).sellerId();
+        List<String> existingOrderNos = orderRepository.findExistingOrderNos(sellerId, new ArrayList<>(incomingOrderNos));
+        if (!existingOrderNos.isEmpty()) {
+            throw new ApiException("중복된 주문번호 존재: " + existingOrderNos, ErrorType.DUPLICATED_ORDER);
+        }
+
+        // 2. OrderBulkDto 생성 및 masterNo → dto 매핑
+        List<OrderBulkDto> orderDtos = new ArrayList<>();
+        Map<String, InternalOrderCreateDto> masterNoToDto = new HashMap<>();
+
+        for (InternalOrderCreateDto dto : requests) {
+            OrderCreateRequest req = dto.request();
+            String masterNo = orderService.generateUniqueMasterNo(req.recipientCountryCode());
+            orderDtos.add(orderDtoMapper.toOrderDto(req, masterNo, dto.sellerId()));
+            masterNoToDto.put(masterNo, dto);
+        }
+
+        // 3. 주문 insert
+        orderJdbcRepository.bulkInsertOrders(orderDtos);
+
+        // 4. masterNo 목록 준비
+        List<String> masterNos = orderDtos.stream()
+            .map(OrderBulkDto::oshipMasterNo)
+            .toList();
+
+        // 5. 주소 DTO 생성 및 insert 먼저 수행
+        List<SenderAddressBulkDto> senderAddresses = new ArrayList<>();
+        List<RecipientAddressBulkDto> recipientAddresses = new ArrayList<>();
+
+        for (String masterNo : masterNos) {
+            InternalOrderCreateDto dto = masterNoToDto.get(masterNo);
+            OrderCreateRequest req = dto.request();
+
+            senderAddresses.add(orderDtoMapper.toSenderAddressDto(req, masterNo));
+            recipientAddresses.add(orderDtoMapper.toRecipientAddressDto(req, masterNo));
+        }
+        orderJdbcRepository.bulkInsertSenderAddresses(senderAddresses);
+        orderJdbcRepository.bulkInsertRecipientAddresses(recipientAddresses);
+
+        // 6. 이제 orderId + addressId 조회
+        Map<String, Long> masterNoToOrderId = orderJdbcRepository.findOrderIdMapByMasterNos(masterNos);
+        Map<String, Long> masterNoToSenderAddressId = orderJdbcRepository.findSenderAddressIdsByMasterNos(masterNos);
+        Map<String, Long> masterNoToRecipientAddressId = orderJdbcRepository.findRecipientAddressIdsByMasterNos(masterNos);
+
+        // 7. 나머지 DTO 생성
+        List<OrderItemBulkDto> items = new ArrayList<>();
+        List<OrderSenderBulkDto> senders = new ArrayList<>();
+        List<OrderRecipientBulkDto> recipients = new ArrayList<>();
+
+        for (String masterNo : masterNos) {
+            InternalOrderCreateDto dto = masterNoToDto.get(masterNo);
+            OrderCreateRequest req = dto.request();
+            Long orderId = masterNoToOrderId.get(masterNo);
+
+            if (orderId == null) {
+                throw new ApiException("orderId 조회 실패: " + masterNo, ErrorType.NOT_FOUND);
+            }
+
+            Long senderAddressId = masterNoToSenderAddressId.get(masterNo);
+            Long recipientAddressId = masterNoToRecipientAddressId.get(masterNo);
+
+            items.addAll(orderDtoMapper.toOrderItemDtos(req, masterNo, orderId));
+            senders.add(orderDtoMapper.toSenderDto(req, orderId, senderAddressId, dto.sellerId()));
+            recipients.add(orderDtoMapper.toRecipientDto(req, orderId, recipientAddressId));
+        }
+
+        // 8. 최종 bulk insert
+        orderJdbcRepository.bulkInsertOrderItems(items);
+        orderJdbcRepository.bulkInsertOrderSenders(senders);
+        orderJdbcRepository.bulkInsertOrderRecipients(recipients);
+
+
+        // OrderBulkRepository ,,, JDBC 기반의 레포지토리에서 실직적인 Insert 작업
+        // 여러 테이블의 insert 메서드를 호출 ,,, 5개의 list DTO 를 넣어서 ....
+
+        // 트래킹 이벤트 등록 (옵션)
+//        for (Order order : orders) {
+//            trackingEventHandler.handleTrackingEvent(
+//                order.getId(),
+//                TrackingEventEnum.ORDER_PLACED,
+//                ""
+//            );
+//        }
+
+
+
+
+        // 9. 완료된 masterNo 반환
+        return masterNos;
+    }
+
+}

--- a/src/main/java/org/example/oshipserver/domain/order/service/OrderService.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/OrderService.java
@@ -41,15 +41,14 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final TrackingEventHandler trackingEventHandler;
 
-    public String createOrder(OrderCreateRequest orderCreateRequest) {
+    public String createOrder(Long userId, OrderCreateRequest orderCreateRequest) {
 
         /** 중복 주문 확인
          * 동일한 seller_id 내에서는 orderNo가 유일해야 하고,
          * seller_id가 다르면 orderNo 중복을 허용
          **/
-        Long sellerId = orderCreateRequest.sellerId();
 
-        if (orderRepository.existsByOrderNoAndSellerId(orderCreateRequest.orderNo(), sellerId)) {
+        if (orderRepository.existsByOrderNoAndSellerId(orderCreateRequest.orderNo(), userId)) {
             throw new ApiException("해당 계정에 동일한 주문번호가 존재합니다: " + orderCreateRequest.orderNo(), ErrorType.DUPLICATED_ORDER);
         }
 
@@ -57,7 +56,7 @@ public class OrderService {
         String masterNo = generateUniqueMasterNo(orderCreateRequest.recipientCountryCode());
 
         // 1. 주문 생성
-        Order order = Order.of(orderCreateRequest, masterNo);
+        Order order = Order.of(orderCreateRequest, masterNo, userId);
 
         // 2. 아이템 생성
         List<OrderItem> items = orderCreateRequest.orderItems().stream()
@@ -128,7 +127,7 @@ public class OrderService {
         return masterNo;
     }
 
-    private String generateUniqueMasterNo(CountryCode countryCode) {
+    public String generateUniqueMasterNo(CountryCode countryCode) {
         String prefix = "OSH";
         String date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyMMdd"));
         String country = (countryCode != null) ? countryCode.name() : "XX";
@@ -189,9 +188,13 @@ public class OrderService {
         value = {CURRENT_MONTH_CACHE, "sellerStats"}, // Redis + Local 캐시 모두 무효화
         key = "T(org.example.oshipserver.global.common.utils.CacheKeyUtil).getRedisCurrentMonthStatsKey(#request.sellerId)"
     )
-    public void updateOrder(Long orderId, OrderUpdateRequest request) {
+    public void updateOrder(Long userId, Long orderId, OrderUpdateRequest request) {
         Order order = orderRepository.findById(orderId)
             .orElseThrow(() -> new ApiException("주문을 찾을 수 없습니다.", ErrorType.NOT_FOUND));
+
+        if (!order.getSellerId().equals(userId)) {
+            throw new ApiException("해당 주문에 접근할 권한이 없습니다.", ErrorType.FORBIDDEN);
+        }
 
         if (order.isDeleted()) {
             throw new ApiException("이미 삭제된 주문입니다.", ErrorType.DB_FAIL);
@@ -209,12 +212,16 @@ public class OrderService {
     }
 
     @Transactional
-    public void softDeleteOrder(Long orderId) {
+    public void softDeleteOrder(Long userId, Long orderId) {
         Order order = orderRepository.findById(orderId)
             .orElseThrow(() -> new ApiException("주문을 찾을 수 없습니다.", ErrorType.NOT_FOUND));
 
         if (order.isDeleted()) {
             throw new ApiException("이미 삭제된 주문입니다.", ErrorType.DB_FAIL);
+        }
+
+        if (!order.getSellerId().equals(userId)) {
+            throw new ApiException("해당 주문에 접근할 권한이 없습니다.", ErrorType.FORBIDDEN);
         }
 
         // 현재 로그인 사용자 정보에서 삭제 주체 추출

--- a/src/main/java/org/example/oshipserver/domain/order/service/bulkmapper/OrderDtoMapper.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/bulkmapper/OrderDtoMapper.java
@@ -1,0 +1,14 @@
+package org.example.oshipserver.domain.order.service.bulkmapper;
+
+import java.util.List;
+import org.example.oshipserver.domain.order.dto.bulk.*;
+import org.example.oshipserver.domain.order.dto.request.OrderCreateRequest;
+
+public interface OrderDtoMapper {
+    OrderBulkDto toOrderDto(OrderCreateRequest req, String masterNo, Long sellerId);
+    List<OrderItemBulkDto> toOrderItemDtos(OrderCreateRequest req, String masterNo, Long orderId);
+    OrderSenderBulkDto toSenderDto(OrderCreateRequest req, Long orderId, Long senderAddressId, Long sellerId);
+    OrderRecipientBulkDto toRecipientDto(OrderCreateRequest req, Long orderId, Long recipientAddressId);
+    SenderAddressBulkDto toSenderAddressDto(OrderCreateRequest req, String masterNo);
+    RecipientAddressBulkDto toRecipientAddressDto(OrderCreateRequest req, String masterNo);
+}

--- a/src/main/java/org/example/oshipserver/domain/order/service/bulkmapper/OrderDtoMapperImpl.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/bulkmapper/OrderDtoMapperImpl.java
@@ -38,8 +38,6 @@ public class OrderDtoMapperImpl implements OrderDtoMapper {
                 item.itemWeight(),
                 item.itemHSCode(),
                 item.itemOriginCountryCode(),
-                item.itemOriginStateCode(),
-                item.itemOriginStateName(),
                 item.weightUnit(),
                 orderId,
                 LocalDateTime.now(),

--- a/src/main/java/org/example/oshipserver/domain/order/service/bulkmapper/OrderDtoMapperImpl.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/bulkmapper/OrderDtoMapperImpl.java
@@ -23,7 +23,7 @@ public class OrderDtoMapperImpl implements OrderDtoMapper {
             req.shipmentActualWeight(), req.shipmentVolumeWeight(),
             (double) req.dimensionWidth(), (double) req.dimensionLength(), (double) req.dimensionHeight(),
             req.packageType(), req.parcelCount(), req.itemContentsType(),
-            false, LocalDateTime.now(), LocalDateTime.now(), sellerId
+            false, LocalDateTime.now(), LocalDateTime.now(), sellerId, req.lastTrackingEvent()
         );
     }
 
@@ -38,6 +38,8 @@ public class OrderDtoMapperImpl implements OrderDtoMapper {
                 item.itemWeight(),
                 item.itemHSCode(),
                 item.itemOriginCountryCode(),
+                item.itemOriginStateCode(),
+                item.itemOriginStateName(),
                 item.weightUnit(),
                 orderId,
                 LocalDateTime.now(),

--- a/src/main/java/org/example/oshipserver/domain/order/service/bulkmapper/OrderDtoMapperImpl.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/bulkmapper/OrderDtoMapperImpl.java
@@ -1,0 +1,105 @@
+package org.example.oshipserver.domain.order.service.bulkmapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.example.oshipserver.domain.order.dto.bulk.OrderBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.OrderItemBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.OrderRecipientBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.OrderSenderBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.RecipientAddressBulkDto;
+import org.example.oshipserver.domain.order.dto.bulk.SenderAddressBulkDto;
+import org.example.oshipserver.domain.order.dto.request.OrderCreateRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderDtoMapperImpl implements OrderDtoMapper {
+
+    @Override
+    public OrderBulkDto toOrderDto(OrderCreateRequest req, String masterNo, Long sellerId) {
+        return new OrderBulkDto(
+            req.orderNo(), masterNo,
+            req.shippingTerm(), req.serviceType(), req.weightUnit(),
+            req.shipmentActualWeight(), req.shipmentVolumeWeight(),
+            (double) req.dimensionWidth(), (double) req.dimensionLength(), (double) req.dimensionHeight(),
+            req.packageType(), req.parcelCount(), req.itemContentsType(),
+            false, LocalDateTime.now(), LocalDateTime.now(), sellerId
+        );
+    }
+
+    @Override
+    public List<OrderItemBulkDto> toOrderItemDtos(OrderCreateRequest req, String masterNo, Long orderId) {
+        return req.orderItems().stream()
+            .map(item -> new OrderItemBulkDto(
+                item.itemName(),
+                item.itemQuantity(),
+                item.itemUnitValue(),
+                item.itemValueCurrency(),
+                item.itemWeight(),
+                item.itemHSCode(),
+                item.itemOriginCountryCode(),
+                item.weightUnit(),
+                orderId,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+            ))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public OrderSenderBulkDto toSenderDto(OrderCreateRequest req, Long orderId, Long senderAddressId, Long sellerId) {
+        return new OrderSenderBulkDto(
+            orderId,
+            sellerId,
+            senderAddressId,
+            req.senderCompany(),
+            req.senderEmail(),
+            req.senderName(),
+            req.senderPhoneNo(),
+            req.storeName(),
+            req.storePlatform()
+        );
+    }
+
+    @Override
+    public OrderRecipientBulkDto toRecipientDto(OrderCreateRequest req, Long orderId, Long recipientAddressId) {
+        return new OrderRecipientBulkDto(
+            orderId,
+            recipientAddressId,
+            req.recipientCompany(),
+            req.recipientEmail(),
+            req.recipientName(),
+            req.recipientPhoneNo()
+        );
+    }
+
+    @Override
+    public SenderAddressBulkDto toSenderAddressDto(OrderCreateRequest req, String masterNo) {
+        return new SenderAddressBulkDto(
+            masterNo,
+            req.senderAddress1(),
+            req.senderAddress2(),
+            req.senderCity(),
+            req.senderState(),
+            req.senderStateCode() != null ? req.senderStateCode().name() : null,
+            req.senderTaxId(),
+            req.senderZipCode(),
+            req.senderCountryCode().name()
+        );
+    }
+
+    @Override
+    public RecipientAddressBulkDto toRecipientAddressDto(OrderCreateRequest req, String masterNo) {
+        return new RecipientAddressBulkDto(
+            masterNo,
+            req.recipientAddress1(),
+            req.recipientAddress2(),
+            req.recipientCity(),
+            req.recipientState(),
+            req.recipientStateCode() != null ? req.recipientStateCode().name() : null,
+            req.recipientTaxId(),
+            req.recipientZipCode(),
+            req.recipientCountryCode().name()
+        );
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/order/service/stats/OrderStatsCacheFacade.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/stats/OrderStatsCacheFacade.java
@@ -1,4 +1,4 @@
-package org.example.oshipserver.domain.order.service;
+package org.example.oshipserver.domain.order.service.stats;
 
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/example/oshipserver/domain/order/service/stats/OrderStatsCacheService.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/stats/OrderStatsCacheService.java
@@ -1,4 +1,4 @@
-package org.example.oshipserver.domain.order.service;
+package org.example.oshipserver.domain.order.service.stats;
 
 import static org.example.oshipserver.global.config.RedisCacheConfig.CURRENT_MONTH_CACHE;
 import static org.example.oshipserver.global.config.RedisCacheConfig.PAST_MONTH_CACHE;

--- a/src/main/java/org/example/oshipserver/domain/order/service/stats/OrderStatsCalculator.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/stats/OrderStatsCalculator.java
@@ -1,4 +1,4 @@
-package org.example.oshipserver.domain.order.service;
+package org.example.oshipserver.domain.order.service.stats;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;

--- a/src/main/java/org/example/oshipserver/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/oshipserver/global/config/SecurityConfig.java
@@ -59,11 +59,15 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("https://seller.oshipapp.com"));
-        config.setAllowedOrigins(List.of("https://partner.oshipapp.com"));
+        config.setAllowedOrigins(List.of(
+            "https://seller.oshipapp.com",
+            "https://partner.oshipapp.com",
+            "http://localhost:5275", //셀러페이지
+            "http://localhost:5274" //파트너페이지
+        ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS","PATCH"));
         config.setAllowedHeaders(List.of("*"));
-        config.setAllowCredentials(true); // 필요한 경우
+        config.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);


### PR DESCRIPTION
## ✏️ Issue
Closes #129 

## ☑️ Todo
* JPA 기반 주문 생성 로직을 JDBC 기반으로 전환
* `JdbcTemplate.batchUpdate`를 이용한 주문/아이템/주소/송수신자 Batch Insert 구현
* `findOrderIdMapByMasterNos()` 등 다중 조회 쿼리를 IN 절 기반으로 최적화
* 중복된 쿼리 반복 제거를 위한 BulkService + Mapper + Repository 분리 구조 설계
* 각 테이블 별 `BulkDto` 도입 및 명시적 필드 매핑 처리

### ⚙️JPA 대신 JDBC 를 선택한 이유 

* JPA는 엔티티 단위로 동작하기 때문에 대량 insert 시 객체 생성, 상태 추적(dirty checking), 영속성 컨텍스트 관리 비용이 **CPU 메모리/GC 부하**로 이어짐
* 특히 `save()` 반복 호출은 내부적으로 매 insert마다 쿼리 준비, flush, cascade 등을 처리하며 **CPU 스파이크와 성능 저하 유발**
* 반면, `JdbcTemplate.batchUpdate()`는 순수 SQL 기반으로 동작하며,

  * **객체 생성 없이 값만 바인딩하고 전송**
  * **PersistenceContext 관리가 불필요**
  * SQL 한 번 준비해 여러 행 처리 → **Statement 재사용 + 네트워크 I/O 감소**

결과적으로 GC 압박 없이 낮은 CPU 사용률을 유지하면서 대량 insert 처리 가능하며, 서버 리소스 효율성과 처리량(TPS)을 동시에 확보할 수 있음.

## ✅ Test Result
v2 bulk insert 기반 확인
![image](https://github.com/user-attachments/assets/e9b71203-9b0c-49bc-a7c9-e6b155ee7278)

CPU 사용률 나쁘지 않은 것 같은데 .. 잘 모르겠네용 ..
![image](https://github.com/user-attachments/assets/beacde36-b8ad-4d9c-b93b-37534ed20cb1)

엑셀에서 sellerId 제외한 후, 로그인한 유저 기반으로 DB에 값 들어오는지 결과 확인
![image](https://github.com/user-attachments/assets/32fd2a25-71b6-4875-84b0-26efe1f0e146)

중복되는 주문번호가 있을 시, 전체 실패
![image](https://github.com/user-attachments/assets/b7029599-ebaf-4dcc-a4fb-e49bdc8ca7ce)

## 💌 Reviewer Notes
+ StateCode 가 null 인 경우,  조회 실패하던 부분도 수정했습니다 ~
++ 주문 대량으로 삽입한 후에 배송 트래킹하는 부분은 추후 수정할 예정입니다.
또 고쳐야할 게 있다면 알려주세요 ~