### PR TITLE
✨[feat] retry-recover 로직 구현 및 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,11 @@ dependencies {
 
 	implementation 'org.apache.httpcomponents.client5:httpclient5'
 
+	// spring retry
+	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:mysql'
 	testImplementation 'org.testcontainers:testcontainers'
+
 	// bcrypt
 	implementation 'at.favre.lib:bcrypt:0.10.2'
 

--- a/src/main/java/org/example/oshipserver/client/toss/IdempotentRestClient.java
+++ b/src/main/java/org/example/oshipserver/client/toss/IdempotentRestClient.java
@@ -92,13 +92,25 @@ public class IdempotentRestClient { // 토스의 post 요청을 멱등성 방식
 
         // RestTemplate을 통해 post 요청
         try {
+            // 이후에 다시 복원예정 (아래의 디버기용 대신)
             ResponseEntity<R> response = restTemplate.exchange(
                 url,
                 HttpMethod.POST,
                 entity,
                 responseType
             );
+            // toss 응답 json을 보기 위한 임시코드(디버깅용 로깅)
+//            ResponseEntity<String> rawResponse = restTemplate.exchange(
+//                url,
+//                HttpMethod.POST,
+//                entity,
+//                String.class
+//            );
+//            log.warn("[Toss 응답 원문 JSON] {}", rawResponse.getBody());
+//
+//            throw new ApiException("Toss 응답 구조 확인 후 복원 필요", ErrorType.TOSS_PAYMENT_FAILED);
 
+            // 이후에 다시 복원예정 (아래의 디버깅용 대신)
             // toss응답이 성공적이여도 body가 null이면 재시도하도록
             if (response.getBody() == null || response.getBody().getClass().getDeclaredMethod("getPaymentKey") != null &&
                 response.getBody().getClass().getMethod("getPaymentKey").invoke(response.getBody()) == null) {
@@ -106,7 +118,7 @@ public class IdempotentRestClient { // 토스의 post 요청을 멱등성 방식
                 throw new ApiException("Toss 응답이 비정상입니다", ErrorType.TOSS_PAYMENT_FAILED);
             }
 
-            // Toss 응답 객체 → JSON 문자열로 변환 (역직렬화 실패하면 toss응답값이 null값으로 반환됨)
+            // Toss 응답 객체 → JSON 문자열로 변환
             try {
                 log.info("[Toss 원문 응답 바디] {}", objectMapper.writeValueAsString(response.getBody()));
             } catch (Exception ex) {

--- a/src/main/java/org/example/oshipserver/client/toss/IdempotentRestClient.java
+++ b/src/main/java/org/example/oshipserver/client/toss/IdempotentRestClient.java
@@ -92,25 +92,13 @@ public class IdempotentRestClient { // 토스의 post 요청을 멱등성 방식
 
         // RestTemplate을 통해 post 요청
         try {
-            // 이후에 다시 복원예정 (아래의 디버기용 대신)
             ResponseEntity<R> response = restTemplate.exchange(
                 url,
                 HttpMethod.POST,
                 entity,
                 responseType
             );
-            // toss 응답 json을 보기 위한 임시코드(디버깅용 로깅)
-//            ResponseEntity<String> rawResponse = restTemplate.exchange(
-//                url,
-//                HttpMethod.POST,
-//                entity,
-//                String.class
-//            );
-//            log.warn("[Toss 응답 원문 JSON] {}", rawResponse.getBody());
-//
-//            throw new ApiException("Toss 응답 구조 확인 후 복원 필요", ErrorType.TOSS_PAYMENT_FAILED);
 
-            // 이후에 다시 복원예정 (아래의 디버깅용 대신)
             // toss응답이 성공적이여도 body가 null이면 재시도하도록
             if (response.getBody() == null || response.getBody().getClass().getDeclaredMethod("getPaymentKey") != null &&
                 response.getBody().getClass().getMethod("getPaymentKey").invoke(response.getBody()) == null) {

--- a/src/main/java/org/example/oshipserver/client/toss/TossRestTemplateConfig.java
+++ b/src/main/java/org/example/oshipserver/client/toss/TossRestTemplateConfig.java
@@ -2,13 +2,18 @@ package org.example.oshipserver.client.toss;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
 
 @Configuration
 public class TossRestTemplateConfig {
 
     @Bean
     public RestTemplate tossRestTemplate() {
-        return new RestTemplate();  // 기본 HTTP 클라이언트 생성 (토스 API 호출)
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setMessageConverters(List.of(new MappingJackson2HttpMessageConverter()));
+        return restTemplate;
     }
 }

--- a/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
@@ -275,16 +275,13 @@ public class Order extends BaseTimeEntity {
     /**
      * 결제 상태에 따른, 주문 상태 업데이트
      */
-    public void markAsPaid() {
-        this.currentStatus = OrderStatus.PAID;
-    }
-    public void markAsCancelled() {
-        this.currentStatus = OrderStatus.CANCELLED;
-    }
-    public void markAsRefunded() {
-        this.currentStatus = OrderStatus.REFUNDED;
-    }
-    public void markAsFailed() {
-        this.currentStatus = OrderStatus.FAILED;
+    public void markAs(OrderStatus nextStatus) {
+        if (!this.currentStatus.canTransitionTo(nextStatus)) {
+            throw new IllegalStateException(
+                String.format("현재 상태 '%s'에서는 상태 '%s'로 전이할 수 없습니다.",
+                    this.currentStatus.name(), nextStatus.name())
+            );
+        }
+        this.currentStatus = nextStatus;
     }
 }

--- a/src/main/java/org/example/oshipserver/domain/order/entity/enums/OrderStatus.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/enums/OrderStatus.java
@@ -1,9 +1,26 @@
 package org.example.oshipserver.domain.order.entity.enums;
 
+import java.util.Set;
+
 public enum OrderStatus {
     PENDING,
     PAID,
     FAILED,
     CANCELLED,
-    REFUNDED
+    REFUNDED;
+
+    private Set<OrderStatus> next;
+
+    static {
+        PENDING.next = Set.of(PAID, CANCELLED, FAILED);
+        PAID.next = Set.of(CANCELLED, REFUNDED);
+        FAILED.next = Set.of(PAID);
+        CANCELLED.next = Set.of(REFUNDED);
+        REFUNDED.next = Set.of();
+    }
+
+    public boolean canTransitionTo(OrderStatus target) {
+        return next.contains(target);
+    }
 }
+

--- a/src/main/java/org/example/oshipserver/domain/order/entity/enums/OrderStatus.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/enums/OrderStatus.java
@@ -1,15 +1,21 @@
 package org.example.oshipserver.domain.order.entity.enums;
 
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public enum OrderStatus {
-    PENDING,
-    PAID,
-    FAILED,
-    CANCELLED,
-    REFUNDED;
+    PENDING(null),
+    PAID(null),
+    FAILED(null),
+    CANCELLED(null),
+    REFUNDED(null);
 
     private Set<OrderStatus> next;
+
+    OrderStatus(Set<OrderStatus> next) {
+        this.next = next;
+    }
 
     static {
         PENDING.next = Set.of(PAID, CANCELLED, FAILED);
@@ -22,5 +28,11 @@ public enum OrderStatus {
     public boolean canTransitionTo(OrderStatus target) {
         return next.contains(target);
     }
-}
 
+    public void assertTransitionTo(OrderStatus target) {
+        if (!canTransitionTo(target)) {
+            log.warn("[OrderStatus 전이 실패] {} → {} 는 허용되지 않는 상태 전이입니다", this, target);
+            throw new IllegalStateException("주문 상태를 " + this + "에서 " + target + "로 전이할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/request/FailedTossRequestDto.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/request/FailedTossRequestDto.java
@@ -1,0 +1,35 @@
+package org.example.oshipserver.domain.payment.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+/**
+ * Toss 실패 요청 큐 적재용 DTO
+ */
+public record FailedTossRequestDto(
+    String url,
+    Map<String, Object> body,
+    String idempotencyKey
+) {
+    @JsonCreator
+    public FailedTossRequestDto(
+        @JsonProperty("url") String url,
+        @JsonProperty("body") Map<String, Object> body,
+        @JsonProperty("idempotencyKey") String idempotencyKey
+    ) {
+        this.url = url;
+        this.body = body;
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    // Toss 결제 승인 요청용 DTO로 변환
+    public PaymentConfirmRequest toConfirmRequest() {
+        return new PaymentConfirmRequest(
+            (String) body.get("paymentKey"),
+            Long.valueOf((String) body.get("orderId")),
+            (String) body.get("orderId"),
+            (Integer) body.get("amount")
+        );
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/response/MultiPaymentConfirmResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/response/MultiPaymentConfirmResponse.java
@@ -30,13 +30,13 @@ public record MultiPaymentConfirmResponse(
     ) {
         return new MultiPaymentConfirmResponse(
             orderIds,
-            response.paymentKey(),
-            PaymentStatusMapper.fromToss(response.status()),
-            response.approvedAt(),
-            response.totalAmount(),
-            response.currency(),
-            response.card() != null ? getLast4Digits(response.card().number()) : null,
-            response.receipt() != null ? response.receipt().url() : null
+            response.getPaymentKey(),
+            PaymentStatusMapper.fromToss(response.getStatus()),
+            response.getApprovedAt(),
+            response.getTotalAmount(),
+            response.getCurrency(),
+            response.getCard() != null ? getLast4Digits(response.getCard().getNumber()) : null,
+            response.getReceipt() != null ? response.getReceipt().getUrl() : null
         );
     }
 

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentConfirmResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/response/PaymentConfirmResponse.java
@@ -26,19 +26,19 @@ public record PaymentConfirmResponse(
         TossPaymentConfirmResponse response,
         PaymentMethod method) {
         return new PaymentConfirmResponse(
-            response.orderId(),
-            response.paymentKey(),
-            PaymentStatusMapper.fromToss(response.status()),
-            response.approvedAt(),
-            response.totalAmount(),
-            response.currency(),
+            response.getOrderId(),
+            response.getPaymentKey(),
+            PaymentStatusMapper.fromToss(response.getStatus()),
+            response.getApprovedAt(),
+            response.getTotalAmount(),
+            response.getCurrency(),
             method,
 //            method == PaymentMethod.CARD && response.card() != null
-            (method == PaymentMethod.EASY_PAY_CARD || method == PaymentMethod.CARD) && response.card() != null
+            (method == PaymentMethod.EASY_PAY_CARD || method == PaymentMethod.CARD) && response.getCard() != null
 
-                ? getLast4Digits(response.card().number())  // 결제방법이 카드일때만 카드4자리 보여줌
+                ? getLast4Digits(response.getCard().getNumber())  // 결제방법이 카드일때만 카드4자리 보여줌
                 : null,
-            response.receipt() != null ? response.receipt().url() : null
+            response.getReceipt() != null ? response.getReceipt().getUrl() : null
         );
 
     }

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/response/TossPaymentConfirmResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/response/TossPaymentConfirmResponse.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class TossPaymentConfirmResponse {
+    // record를 class로 리팩토링 ; record는 Jackson 역직렬화 잘 안 됨
 
     @JsonProperty("mid")
     private String mId;

--- a/src/main/java/org/example/oshipserver/domain/payment/dto/response/TossPaymentConfirmResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/dto/response/TossPaymentConfirmResponse.java
@@ -1,67 +1,170 @@
 package org.example.oshipserver.domain.payment.dto.response;
 
-/**
- * Toss 단건 결제 승인 응답 전체 DTO
- */
-public record TossPaymentConfirmResponse(
-    String mId,
-    String lastTransactionKey,
-    String paymentKey,
-    String orderId,
-    String orderName,
-    int taxExemptionAmount,
-    String status,
-    String requestedAt,
-    String approvedAt,
-    boolean useEscrow,
-    boolean cultureExpense,
-    Card card,
-    String type,
-    EasyPay easyPay,
-    String country,
-    Failure failure,
-    boolean isPartialCancelable,
-    Receipt receipt,
-    Checkout checkout,
-    String currency,
-    int totalAmount,
-    int balanceAmount,
-    int suppliedAmount,
-    int vat,
-    int taxFreeAmount,
-    String method,
-    String version
-) {
-    public record Card(
-        String issuerCode,
-        String acquirerCode,
-        String number,
-        int installmentPlanMonths,
-        boolean isInterestFree,
-        String approveNo,
-        boolean useCardPoint,
-        String cardType,
-        String ownerType,
-        String acquireStatus,
-        int amount
-    ) {}
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
 
-    public record EasyPay(
-        String provider,
-        int amount,
-        int discountAmount
-    ) {}
+@Getter
+@Setter
+public class TossPaymentConfirmResponse {
 
-    public record Failure(
-        String code,
-        String message
-    ) {}
+    @JsonProperty("mid")
+    private String mId;
 
-    public record Receipt(
-        String url
-    ) {}
+    @JsonProperty("lastTransactionKey")
+    private String lastTransactionKey;
 
-    public record Checkout(
-        String url
-    ) {}
+    @JsonProperty("paymentKey")
+    private String paymentKey;
+
+    @JsonProperty("orderId")
+    private String orderId;
+
+    @JsonProperty("orderName")
+    private String orderName;
+
+    @JsonProperty("taxExemptionAmount")
+    private int taxExemptionAmount;
+
+    @JsonProperty("status")
+    private String status;
+
+    @JsonProperty("requestedAt")
+    private String requestedAt;
+
+    @JsonProperty("approvedAt")
+    private String approvedAt;
+
+    @JsonProperty("useEscrow")
+    private boolean useEscrow;
+
+    @JsonProperty("cultureExpense")
+    private boolean cultureExpense;
+
+    @JsonProperty("card")
+    private Card card;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("easyPay")
+    private EasyPay easyPay;
+
+    @JsonProperty("country")
+    private String country;
+
+    @JsonProperty("failure")
+    private Failure failure;
+
+    @JsonProperty("partialCancelable")
+    private boolean isPartialCancelable;
+
+    @JsonProperty("receipt")
+    private Receipt receipt;
+
+    @JsonProperty("checkout")
+    private Checkout checkout;
+
+    @JsonProperty("currency")
+    private String currency;
+
+    @JsonProperty("totalAmount")
+    private int totalAmount;
+
+    @JsonProperty("balanceAmount")
+    private int balanceAmount;
+
+    @JsonProperty("suppliedAmount")
+    private int suppliedAmount;
+
+    @JsonProperty("vat")
+    private int vat;
+
+    @JsonProperty("taxFreeAmount")
+    private int taxFreeAmount;
+
+    @JsonProperty("method")
+    private String method;
+
+    @JsonProperty("version")
+    private String version;
+
+    @Getter
+    @Setter
+    public static class Card {
+
+        @JsonProperty("issuerCode")
+        private String issuerCode;
+
+        @JsonProperty("acquirerCode")
+        private String acquirerCode;
+
+        @JsonProperty("number")
+        private String number;
+
+        @JsonProperty("installmentPlanMonths")
+        private int installmentPlanMonths;
+
+        @JsonProperty("isInterestFree")
+        private boolean isInterestFree;
+
+        @JsonProperty("approveNo")
+        private String approveNo;
+
+        @JsonProperty("useCardPoint")
+        private boolean useCardPoint;
+
+        @JsonProperty("cardType")
+        private String cardType;
+
+        @JsonProperty("ownerType")
+        private String ownerType;
+
+        @JsonProperty("acquireStatus")
+        private String acquireStatus;
+
+        @JsonProperty("amount")
+        private int amount;
+    }
+
+    @Getter
+    @Setter
+    public static class EasyPay {
+
+        @JsonProperty("provider")
+        private String provider;
+
+        @JsonProperty("amount")
+        private int amount;
+
+        @JsonProperty("discountAmount")
+        private int discountAmount;
+    }
+
+    @Getter
+    @Setter
+    public static class Failure {
+
+        @JsonProperty("code")
+        private String code;
+
+        @JsonProperty("message")
+        private String message;
+    }
+
+    @Getter
+    @Setter
+    public static class Receipt {
+
+        @JsonProperty("url")
+        private String url;
+    }
+
+    @Getter
+    @Setter
+    public static class Checkout {
+
+        @JsonProperty("url")
+        private String url;
+    }
 }

--- a/src/main/java/org/example/oshipserver/domain/payment/entity/Payment.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/entity/Payment.java
@@ -120,24 +120,22 @@ public class Payment extends BaseTimeEntity {
         this.sellerId = sellerId;
     }
 
-    public void updateStatus(PaymentStatus status) {
-        this.status = status;
+    public void updateStatus(PaymentStatus nextStatus) {
+        if (!this.status.canTransitionTo(nextStatus)) {
+            throw new IllegalStateException(
+                String.format("현재 상태 '%s'에서는 상태 '%s'로 전이할 수 없습니다.",
+                    this.status.name(), nextStatus.name())
+            );
+        }
+        this.status = nextStatus;
     }
 
-    public void cancel() {
-        this.status = PaymentStatus.CANCEL;
-    }
-
-    public void partialCancel(int cancelAmount, String cancelReason) {
+    public void partialCancel(int cancelAmount) {
         // 전체 금액보다 많을 수 없도록 제어할 수도 있음
         if (cancelAmount <= 0 || cancelAmount > this.amount) {
             throw new IllegalArgumentException("부분 취소 금액이 유효하지 않습니다.");
         }
-
-        // 부분 취소 상태로 변경
-        this.status = PaymentStatus.PARTIAL_CANCEL;
-
-        // 추후 이력 관리나 누적 취소 금액 관리로 확장 예정
+        // 추후 이력 관리나 누적 취소 금액 관리로 확장 가능
     }
 
     @Column(name = "idempotency_key", nullable = false, unique = true)

--- a/src/main/java/org/example/oshipserver/domain/payment/entity/Payment.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/entity/Payment.java
@@ -107,7 +107,8 @@ public class Payment extends BaseTimeEntity {
     @Builder
     public Payment(String paymentNo, String paymentKey, String tossOrderId,
         PaymentStatus status, PaymentMethod method, Integer amount,
-        String currency, LocalDateTime paidAt, String failReason, Long sellerId) {
+        String currency, LocalDateTime paidAt, String failReason, Long sellerId,
+        String idempotencyKey) {
         this.paymentNo = paymentNo;
         this.paymentKey = paymentKey;
         this.tossOrderId = tossOrderId;
@@ -118,6 +119,7 @@ public class Payment extends BaseTimeEntity {
         this.paidAt = paidAt;
         this.failReason = failReason;
         this.sellerId = sellerId;
+        this.idempotencyKey = idempotencyKey;
     }
 
     public void updateStatus(PaymentStatus nextStatus) {

--- a/src/main/java/org/example/oshipserver/domain/payment/entity/Payment.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/entity/Payment.java
@@ -78,6 +78,10 @@ public class Payment extends BaseTimeEntity {
     @OneToMany(mappedBy = "payment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PaymentOrder> paymentOrders = new ArrayList<>();
 
+    public void addPaymentOrder(PaymentOrder paymentOrder) {
+        this.paymentOrders.add(paymentOrder);
+    }
+
     // 직접 매핑된 주문 리스트만 추출
     public List<Order> getOrders() {
         return paymentOrders.stream()

--- a/src/main/java/org/example/oshipserver/domain/payment/entity/Payment.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/entity/Payment.java
@@ -120,17 +120,8 @@ public class Payment extends BaseTimeEntity {
         this.sellerId = sellerId;
     }
 
-    public void markSuccess(String paymentKey, LocalDateTime paidAt, String cardLast4Digits, String receiptUrl) {
-        this.paymentKey = paymentKey;
-        this.status = PaymentStatus.COMPLETE;
-        this.paidAt = paidAt;
-        this.cardLast4Digits = cardLast4Digits;
-        this.receiptUrl = receiptUrl;
-    }
-
-    public void markFailed(String reason) {
-        this.status = PaymentStatus.FAIL;
-        this.failReason = reason;
+    public void updateStatus(PaymentStatus status) {
+        this.status = status;
     }
 
     public void cancel() {
@@ -148,6 +139,9 @@ public class Payment extends BaseTimeEntity {
 
         // 추후 이력 관리나 누적 취소 금액 관리로 확장 예정
     }
+
+    @Column(name = "idempotency_key", nullable = false, unique = true)
+    private String idempotencyKey;
 
 //    // payment > paymentOrder > order르 통해 sellerId 가지고 오는 것보다
 //    // payment엔티티에서 결제자 id를 직접 가지고 있도록 연관관계를 맺는게 효율적

--- a/src/main/java/org/example/oshipserver/domain/payment/entity/PaymentFailLog.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/entity/PaymentFailLog.java
@@ -1,0 +1,44 @@
+package org.example.oshipserver.domain.payment.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+import org.example.oshipserver.global.entity.BaseTimeEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PaymentFailLog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 실패한 요청 URL (ex. Toss 결제 승인 요청 URL)
+    @Column(nullable = false, length = 500)
+    private String url;
+
+    // 실패한 요청 바디 (JSON 문자열 형태로 직렬화)
+    @Lob
+    @Column(nullable = false)
+    private String requestBody;
+
+    // Idempotency-Key 값
+    @Column(nullable = false, length = 100)
+    private String idempotencyKey;
+
+    // 실패 사유 또는 에러 메시지
+    @Column(nullable = false, length = 1000)
+    private String errorMessage;
+
+    private LocalDateTime failedAt;
+
+    @PrePersist
+    protected void onPrePersist() {
+        if (this.failedAt == null) {
+            this.failedAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/entity/PaymentStatus.java
@@ -1,11 +1,29 @@
 package org.example.oshipserver.domain.payment.entity;
 
+import java.util.Set;
+
 public enum PaymentStatus {
-    NONE,  // 결제 없음
-    WAIT,  // 결제 대기
-    COMPLETE,  // 승인 완료
-    PARTIAL_CANCEL,  // 승인 부분 취소
-    CANCEL,  // 승인 취소
-    FAIL,  // 승인 실패
-    WAIT_CANCEL;  // 결제 대기 취소
+    NONE, // 결제 없음
+    WAIT, // 결제 대기
+    WAIT_CANCEL, // 결제 대기 취소
+    COMPLETE, // 승인 완료
+    PARTIAL_CANCEL, // 승인 부분 취소
+    CANCEL, // 승인 취소
+    FAIL; // 승인 실패
+
+    private Set<PaymentStatus> next;
+
+    static {
+        NONE.next = Set.of(WAIT, WAIT_CANCEL, COMPLETE, FAIL);
+        WAIT.next = Set.of(COMPLETE, FAIL, WAIT_CANCEL);
+        WAIT_CANCEL.next = Set.of();
+        COMPLETE.next = Set.of(PARTIAL_CANCEL, CANCEL);
+        PARTIAL_CANCEL.next = Set.of(CANCEL);
+        CANCEL.next = Set.of();
+        FAIL.next = Set.of();
+    }
+
+    public boolean canTransitionTo(PaymentStatus target) {
+        return next.contains(target);
+    }
 }

--- a/src/main/java/org/example/oshipserver/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/entity/PaymentStatus.java
@@ -3,24 +3,28 @@ package org.example.oshipserver.domain.payment.entity;
 import java.util.Set;
 
 public enum PaymentStatus {
-    NONE, // 결제 없음
-    WAIT, // 결제 대기
-    WAIT_CANCEL, // 결제 대기 취소
-    COMPLETE, // 승인 완료
-    PARTIAL_CANCEL, // 승인 부분 취소
-    CANCEL, // 승인 취소
-    FAIL; // 승인 실패
+    NONE(null), // 결제 없음
+    WAIT(null), // 결제 대기
+    WAIT_CANCEL(null), // 결제 대기 취소
+    COMPLETE(null), // 승인 완료
+    PARTIAL_CANCEL(null), // 승인 부분 취소
+    CANCEL(null), // 승인 취소
+    FAIL(null); // 승인 실패
 
     private Set<PaymentStatus> next;
+
+    PaymentStatus(Set<PaymentStatus> next) {
+        this.next = next;
+    }
 
     static {
         NONE.next = Set.of(WAIT, WAIT_CANCEL, COMPLETE, FAIL);
         WAIT.next = Set.of(COMPLETE, FAIL, WAIT_CANCEL);
-        WAIT_CANCEL.next = Set.of();
+        WAIT_CANCEL.next = Set.of(COMPLETE, FAIL);
         COMPLETE.next = Set.of(PARTIAL_CANCEL, CANCEL);
         PARTIAL_CANCEL.next = Set.of(CANCEL);
         CANCEL.next = Set.of();
-        FAIL.next = Set.of();
+        FAIL.next = Set.of(WAIT,WAIT_CANCEL, COMPLETE, PARTIAL_CANCEL, CANCEL);
     }
 
     public boolean canTransitionTo(PaymentStatus target) {

--- a/src/main/java/org/example/oshipserver/domain/payment/mapper/PaymentMethodMapper.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/mapper/PaymentMethodMapper.java
@@ -8,12 +8,12 @@ import org.example.oshipserver.global.exception.ErrorType;
 public class PaymentMethodMapper {
 
     public static PaymentMethod fromToss(TossPaymentConfirmResponse response) {
-        String method = response.method();
+        String method = response.getMethod();
 
         // 간편결제(easypay): 토스페이
         if ("간편결제".equals(method)) {
-            if (response.easyPay() != null && "토스페이".equals(response.easyPay().provider())) {  // provider가 토스페이인지 꼭 체크
-                if (response.card() != null) {  // 카드값 null여부로 카드/계좌 구분함
+            if (response.getEasyPay() != null && "토스페이".equals(response.getEasyPay().getProvider())) {  // provider가 토스페이인지 꼭 체크
+                if (response.getCard() != null) {  // 카드값 null여부로 카드/계좌 구분함
                     return PaymentMethod.EASY_PAY_CARD; // 토스 카드 결제
                 } else {
                     return PaymentMethod.EASY_PAY_ACCOUNT; // 토스 계좌 결제

--- a/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentFailLogRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentFailLogRepository.java
@@ -1,0 +1,9 @@
+package org.example.oshipserver.domain.payment.repository;
+
+import org.example.oshipserver.domain.payment.entity.PaymentFailLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaymentFailLogRepository extends JpaRepository<PaymentFailLog, Long> {
+}

--- a/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/repository/PaymentRepository.java
@@ -27,4 +27,5 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     // 날짜 + sellerId 기준으로 결제 조회
     List<Payment> findBySellerIdAndCreatedAtBetween(Long sellerId, LocalDateTime start, LocalDateTime end);
 
+    Optional<Payment> findByIdempotencyKey(String idempotencyKey);
 }

--- a/src/main/java/org/example/oshipserver/domain/payment/service/FailedRequestRetryService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/FailedRequestRetryService.java
@@ -1,0 +1,40 @@
+package org.example.oshipserver.domain.payment.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.oshipserver.domain.payment.dto.request.FailedTossRequestDto;
+import org.example.oshipserver.client.toss.TossPaymentClient;
+import org.example.oshipserver.global.common.component.RedisService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FailedRequestRetryService {
+    // 큐에 쌓인 결제 실패 요청을 다시 재처리
+
+    private final RedisService redisService;
+    private final ObjectMapper objectMapper;
+    private final TossPaymentClient tossPaymentClient;
+
+    private static final String REDIS_KEY = "failed:toss:requests";
+
+    @Scheduled(fixedDelay = 60000) // 메서드가 주기적으로 실행됨. 1분마다 재시도.
+    public void retryFailedTossRequests() {
+        while (true) {
+            String json = redisService.popFromList(REDIS_KEY);  // redis에서 pop해서 실패 요청을 하나씩 꺼냄
+            if (json == null) break;  // 큐가 비어있으면, 반복 종료
+
+            try {
+                FailedTossRequestDto dto = objectMapper.readValue(json, FailedTossRequestDto.class); // json 문자열을 FailedTossRequestDto로 변환
+                tossPaymentClient.retryPaymentConfirm(dto); // Toss 결재 재시도 api 호출
+                log.info("Toss 재시도 성공: {}", dto.idempotencyKey());
+            } catch (Exception e) {
+                log.error("Toss 재시도 실패: {}", json, e);
+                // 재시도 실패시, redis에 재삽입 안 함. 무한 재시도 방지.
+            }
+        }
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/payment/service/FailedRequestRetryService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/FailedRequestRetryService.java
@@ -21,7 +21,7 @@ public class FailedRequestRetryService {
 
     private static final String REDIS_KEY = "failed:toss:requests";
 
-    @Scheduled(fixedDelay = 60000) // 메서드가 주기적으로 실행됨. 1분마다 재시도.
+    @Scheduled(fixedDelay = 600_000) // 10분마다 메서드가 주기적으로 실행됨 (스케줄러)
     public void retryFailedTossRequests() {
         while (true) {
             String json = redisService.popFromList(REDIS_KEY);  // redis에서 pop해서 실패 요청을 하나씩 꺼냄

--- a/src/main/java/org/example/oshipserver/domain/payment/service/FailedRequestRetryService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/FailedRequestRetryService.java
@@ -9,32 +9,36 @@ import org.example.oshipserver.global.common.component.RedisService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-@Slf4j
-@Service
-@RequiredArgsConstructor
+//@Slf4j
+//@Service
+//@RequiredArgsConstructor
 public class FailedRequestRetryService {
-    // 큐에 쌓인 결제 실패 요청을 다시 재처리
+    /**
+     * Redis 큐에 쌓인 Toss의 실패 요청을 스케줄러를 사용하여 재처리하는 로직
+     * 현재 단건/다건 결제에서는 사용하지 않지만, 추후 정기결제에서 사용하거나
+     * 외부 api 실패 재처리를 위해 다시 사용할 수 있으므로 주석처리
+     */
 
-    private final RedisService redisService;
-    private final ObjectMapper objectMapper;
-    private final TossPaymentClient tossPaymentClient;
-
-    private static final String REDIS_KEY = "failed:toss:requests";
-
-    @Scheduled(fixedDelay = 600_000) // 10분마다 메서드가 주기적으로 실행됨 (스케줄러)
-    public void retryFailedTossRequests() {
-        while (true) {
-            String json = redisService.popFromList(REDIS_KEY);  // redis에서 pop해서 실패 요청을 하나씩 꺼냄
-            if (json == null) break;  // 큐가 비어있으면, 반복 종료
-
-            try {
-                FailedTossRequestDto dto = objectMapper.readValue(json, FailedTossRequestDto.class); // json 문자열을 FailedTossRequestDto로 변환
-                tossPaymentClient.retryPaymentConfirm(dto); // Toss 결재 재시도 api 호출
-                log.info("Toss 재시도 성공: {}", dto.idempotencyKey());
-            } catch (Exception e) {
-                log.error("Toss 재시도 실패: {}", json, e);
-                // 재시도 실패시, redis에 재삽입 안 함. 무한 재시도 방지.
-            }
-        }
-    }
+//    private final RedisService redisService;
+//    private final ObjectMapper objectMapper;
+//    private final TossPaymentClient tossPaymentClient;
+//
+//    private static final String REDIS_KEY = "failed:toss:requests";
+//
+//    @Scheduled(fixedDelay = 600_000) // 10분마다 메서드가 주기적으로 실행됨 (스케줄러)
+//    public void retryFailedTossRequests() {
+//        while (true) {
+//            String json = redisService.popFromList(REDIS_KEY);  // redis에서 pop해서 실패 요청을 하나씩 꺼냄
+//            if (json == null) break;  // 큐가 비어있으면, 반복 종료
+//
+//            try {
+//                FailedTossRequestDto dto = objectMapper.readValue(json, FailedTossRequestDto.class); // json 문자열을 FailedTossRequestDto로 변환
+//                tossPaymentClient.retryPaymentConfirm(dto); // Toss 결재 재시도 api 호출
+//                log.info("Toss 재시도 성공: {}", dto.idempotencyKey());
+//            } catch (Exception e) {
+//                log.error("Toss 재시도 실패: {}", json, e);
+//                // 재시도 실패시, redis에 재삽입 안 함. 무한 재시도 방지.
+//            }
+//        }
+//    }
 }

--- a/src/main/java/org/example/oshipserver/domain/payment/service/PaymentFailLogService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/PaymentFailLogService.java
@@ -1,0 +1,35 @@
+package org.example.oshipserver.domain.payment.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.oshipserver.domain.payment.entity.PaymentFailLog;
+import org.example.oshipserver.domain.payment.repository.PaymentFailLogRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentFailLogService {
+    // toss api 호출이 최종 실패했을 때, 실패 내역을 PaymentFailLog에 저장
+
+    private final PaymentFailLogRepository paymentFailLogRepository;
+
+    public void saveFailLog(String url, Map<String, Object> body, String idempotencyKey) {
+        try {
+            PaymentFailLog failLog = PaymentFailLog.builder()
+                .url(url)
+                .requestBody(body.toString())  // JSON 직렬화 대신 단순 toString, 필요시 ObjectMapper 적용 가능
+                .idempotencyKey(idempotencyKey)
+                .failedAt(LocalDateTime.now())
+                .build();
+
+            paymentFailLogRepository.save(failLog);
+            log.info("결제 실패 로그 저장 완료 - 키: {}", idempotencyKey);
+        } catch (Exception e) {
+            log.error("결제 실패 로그 저장 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/org/example/oshipserver/global/common/component/RedisService.java
+++ b/src/main/java/org/example/oshipserver/global/common/component/RedisService.java
@@ -4,34 +4,39 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-@Service
-@RequiredArgsConstructor
-public class RedisService { // @Recover에서 사용할 redis 큐 적재,조회
-
-    private final RedisTemplate<String, String> stringRedisTemplate;
-
+//@Service
+//@RequiredArgsConstructor
+public class RedisService {
     /**
-     * Redis 리스트(큐)에 실패요청(JSON) 추가
-     * @param key Redis 리스트 키s
-     * @param jsonValue 직렬화된 요청 본문 (JSON)
+     * @Recover에서 사용할 redis 큐 적재,조회
+     * 현재 단건/다건 결제에서는 사용하지 않지만, 추후 정기결제에서 사용하거나
+     * 외부 api 실패 재처리를 위해 다시 사용할 수 있으므로 주석처리
      */
-    public void pushToList(String key, String jsonValue) {
-        stringRedisTemplate.opsForList().rightPush(key, jsonValue);
-    }
 
-    /**
-     * Redis 리스트(큐)에서 가장 오래된 요청 꺼내기(재처리 시 사용)
-     * @param key Redis 리스트 키
-     * @return JSON 문자열 (직렬화된 요청), 없으면 null
-     */
-    public String popFromList(String key) {
-        return stringRedisTemplate.opsForList().leftPop(key);
-    }
-
-    /**
-     * 큐 길이 조회
-     */
-    public Long getQueueSize(String key) {
-        return stringRedisTemplate.opsForList().size(key);
-    }
+//    private final RedisTemplate<String, String> stringRedisTemplate;
+//
+//    /**
+//     * Redis 리스트(큐)에 실패요청(JSON) 추가
+//     * @param key Redis 리스트 키s
+//     * @param jsonValue 직렬화된 요청 본문 (JSON)
+//     */
+//    public void pushToList(String key, String jsonValue) {
+//        stringRedisTemplate.opsForList().rightPush(key, jsonValue);
+//    }
+//
+//    /**
+//     * Redis 리스트(큐)에서 가장 오래된 요청 꺼내기(재처리 시 사용)
+//     * @param key Redis 리스트 키
+//     * @return JSON 문자열 (직렬화된 요청), 없으면 null
+//     */
+//    public String popFromList(String key) {
+//        return stringRedisTemplate.opsForList().leftPop(key);
+//    }
+//
+//    /**
+//     * 큐 길이 조회
+//     */
+//    public Long getQueueSize(String key) {
+//        return stringRedisTemplate.opsForList().size(key);
+//    }
 }

--- a/src/main/java/org/example/oshipserver/global/common/component/RedisService.java
+++ b/src/main/java/org/example/oshipserver/global/common/component/RedisService.java
@@ -1,0 +1,37 @@
+package org.example.oshipserver.global.common.component;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService { // @Recover에서 사용할 redis 큐 적재,조회
+
+    private final RedisTemplate<String, String> stringRedisTemplate;
+
+    /**
+     * Redis 리스트(큐)에 실패요청(JSON) 추가
+     * @param key Redis 리스트 키s
+     * @param jsonValue 직렬화된 요청 본문 (JSON)
+     */
+    public void pushToList(String key, String jsonValue) {
+        stringRedisTemplate.opsForList().rightPush(key, jsonValue);
+    }
+
+    /**
+     * Redis 리스트(큐)에서 가장 오래된 요청 꺼내기(재처리 시 사용)
+     * @param key Redis 리스트 키
+     * @return JSON 문자열 (직렬화된 요청), 없으면 null
+     */
+    public String popFromList(String key) {
+        return stringRedisTemplate.opsForList().leftPop(key);
+    }
+
+    /**
+     * 큐 길이 조회
+     */
+    public Long getQueueSize(String key) {
+        return stringRedisTemplate.opsForList().size(key);
+    }
+}

--- a/src/main/java/org/example/oshipserver/global/config/RetryConfig.java
+++ b/src/main/java/org/example/oshipserver/global/config/RetryConfig.java
@@ -1,0 +1,10 @@
+package org.example.oshipserver.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+
+}

--- a/src/main/java/org/example/oshipserver/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/oshipserver/global/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/sellers/**").hasRole("SELLER")
                         .requestMatchers("/api/v1/partners/**").hasRole("PARTNER")
                         .requestMatchers("/api/v1/payments/**").hasRole("SELLER")
+//                        .requestMatchers("/api/v1/payments/**").permitAll()
                         .anyRequest().authenticated()
 
                 )

--- a/src/main/java/org/example/oshipserver/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/oshipserver/global/config/SecurityConfig.java
@@ -38,7 +38,6 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/sellers/**").hasRole("SELLER")
                         .requestMatchers("/api/v1/partners/**").hasRole("PARTNER")
                         .requestMatchers("/api/v1/payments/**").hasRole("SELLER")
-//                        .requestMatchers("/api/v1/payments/**").permitAll()
                         .anyRequest().authenticated()
 
                 )

--- a/src/main/java/org/example/oshipserver/global/exception/ApiException.java
+++ b/src/main/java/org/example/oshipserver/global/exception/ApiException.java
@@ -5,23 +5,41 @@ import lombok.RequiredArgsConstructor;
 
 
 @Getter
-@RequiredArgsConstructor
 public class ApiException extends RuntimeException{
 
-    private final String message;
     private final ErrorType errorType;
 
-    // 외부 오류용(Toss): ErrorType 없이 message만 전달
+    /**
+     * ErrorType만 전달할 경우 (errorType의 메시지를 사용)
+     */
+    public ApiException(ErrorType errorType) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+    }
+
+    /**
+     * 외부 API 오류 등으로 message만 따로 지정
+     * ErrorType : 기본값인 INTERNAL_SERVER_ERROR
+     */
     public ApiException(String message) {
         super(message);
-        this.message = message;
         this.errorType = ErrorType.INTERNAL_SERVER_ERROR;
     }
 
-    // 외부 오류용(Toss) : e.getResponseBodyAsString()과 함께 전달
+    /**
+     * 원인 예외 포함 + message 지정 시 사용
+     * ErrorType : 기본값인 INTERNAL_SERVER_ERROR
+     */
     public ApiException(String message, Throwable cause) {
         super(message, cause);
-        this.message = message;
         this.errorType = ErrorType.INTERNAL_SERVER_ERROR;
+    }
+
+    /**
+     * message + ErrorType 모두 직접 지정
+     */
+    public ApiException(String message, ErrorType errorType) {
+        super(message);
+        this.errorType = errorType;
     }
 }

--- a/src/main/java/org/example/oshipserver/global/exception/ErrorType.java
+++ b/src/main/java/org/example/oshipserver/global/exception/ErrorType.java
@@ -34,6 +34,7 @@ public enum ErrorType{
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청이 올바르지 않습니다."),
     INVALID_ORDER(HttpStatus.BAD_REQUEST, "해당 주문은 이 결제에 포함되어 있지 않습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    REDIS_RETRY_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "재시도 중 장애 발생, 나중에 다시 시도해주세요"),
 
     // Shipping/Barcode 관련 에러
     BARCODE_NOT_PRINTED(HttpStatus.BAD_REQUEST, "바코드가 출력되지 않았습니다."),
@@ -48,5 +49,10 @@ public enum ErrorType{
 
     private final HttpStatus status;
     private final String desc;
+
+    public String getMessage() {
+        return desc;
+    }
+
 }
 

--- a/src/main/java/org/example/oshipserver/global/exception/ErrorType.java
+++ b/src/main/java/org/example/oshipserver/global/exception/ErrorType.java
@@ -34,6 +34,8 @@ public enum ErrorType{
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청이 올바르지 않습니다."),
     INVALID_ORDER(HttpStatus.BAD_REQUEST, "해당 주문은 이 결제에 포함되어 있지 않습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    PAYMENT_STATUS_TRANSITION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 상태 전이에 실패했습니다."),
+    PAYMENT_INVALID_CANCEL_AMOUNT(HttpStatus.BAD_REQUEST, "부분취소 금액이 유효하지 않습니다."),
 
     // TOSS API 호출 에러
     REDIS_RETRY_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "재시도 중 장애 발생, 나중에 다시 시도해주세요"),

--- a/src/main/java/org/example/oshipserver/global/exception/ErrorType.java
+++ b/src/main/java/org/example/oshipserver/global/exception/ErrorType.java
@@ -34,7 +34,10 @@ public enum ErrorType{
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청이 올바르지 않습니다."),
     INVALID_ORDER(HttpStatus.BAD_REQUEST, "해당 주문은 이 결제에 포함되어 있지 않습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+
+    // TOSS API 호출 에러
     REDIS_RETRY_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "재시도 중 장애 발생, 나중에 다시 시도해주세요"),
+    TOSS_PAYMENT_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "결제 요청 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
 
     // Shipping/Barcode 관련 에러
     BARCODE_NOT_PRINTED(HttpStatus.BAD_REQUEST, "바코드가 출력되지 않았습니다."),

--- a/src/main/java/org/example/oshipserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/oshipserver/global/exception/GlobalExceptionHandler.java
@@ -47,7 +47,7 @@ public class GlobalExceptionHandler {
                 .status(e.getErrorType().getStatus())
                 .body(new BaseExceptionResponse(
                         e.getErrorType().getStatus().value(),
-                        e.getMessage()
+                        e.getErrorType().getMessage()
                 ));
     }
 

--- a/src/test/java/org/example/oshipserver/client/toss/IdempotentRestClientTest.java
+++ b/src/test/java/org/example/oshipserver/client/toss/IdempotentRestClientTest.java
@@ -10,12 +10,14 @@ import org.example.oshipserver.domain.payment.entity.PaymentOrder;
 import org.example.oshipserver.domain.payment.repository.PaymentFailLogRepository;
 import org.example.oshipserver.domain.payment.repository.PaymentRepository;
 import org.example.oshipserver.global.exception.ApiException;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.HttpServerErrorException;
@@ -28,81 +30,145 @@ import org.example.oshipserver.domain.payment.entity.PaymentStatus;
 import org.example.oshipserver.domain.order.entity.enums.OrderStatus;
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
-@TestPropertySource(properties = "toss.secret-key=test_sk")
+//@SpringBootTest
+//@TestPropertySource(properties = "toss.secret-key=test_sk")
+//class IdempotentRestClientRetryRecoverTest {
+//
+//    @Autowired
+//    private IdempotentRestClient restClient;
+//
+//    @MockBean
+//    private RestTemplate restTemplate;
+//
+//    @MockBean
+//    private PaymentFailLogRepository paymentFailLogRepository;
+//
+//    @MockBean
+//    private PaymentRepository paymentRepository;
+//
+//    @MockBean
+//    private OrderRepository orderRepository;
+//
+//    @Autowired
+//    private ObjectMapper objectMapper;
+//
+//    private static final String URL = "https://api.tosspayments.com/v1/payments/confirm";
+//    private static final String IDEMPOTENCY_KEY = "recover-test-key";
+//
+//    @Test
+//    void externalApiFails_retryOccurs_thenRecoverExecuted() throws Exception {
+//        // 외부 결제 api 호출이 실패할 때까지 retry가 3번 수행되고, 마지막에 @Recover 로직이 실행되는지
+//        // given : toss 결제승인api에 보낼 request body 준비
+//        Map<String, Object> requestBody = Map.of(
+//            "paymentKey", "abc123",
+//            "orderId", "ORD123",
+//            "amount", 10000
+//        );
+//
+//        // Toss API 호출시, 항상 500에러 (retry 대상)
+//        when(restTemplate.exchange(
+//            any(), eq(HttpMethod.POST), any(), eq(TossPaymentConfirmResponse.class))
+//        ).thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+//
+//        // recover 실행 시 필요한 설정
+//        Payment dummyPayment = Payment.builder()
+//            .paymentNo("1")
+//            .status(PaymentStatus.WAIT)
+//            .idempotencyKey(IDEMPOTENCY_KEY)
+//            .build();
+//
+//        Order dummyOrder = Order.builder()
+//            .currentStatus(OrderStatus.PENDING)
+//            .build();
+//        ReflectionTestUtils.setField(dummyOrder, "id", 10L);
+//
+//        PaymentOrder paymentOrder = PaymentOrder.builder()
+//            .order(dummyOrder)
+//            .build();
+//
+//        dummyPayment.addPaymentOrder(paymentOrder);
+//
+//        when(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY))
+//            .thenReturn(Optional.of(dummyPayment));
+//
+//        // mock를 실제 직렬화 수행
+//        String json = objectMapper.writeValueAsString(requestBody);
+//
+//        // when : toss api 호출시, 항상 ApiException 발생
+//        assertThrows(ApiException.class, () -> {
+//            restClient.postForIdempotent(URL, requestBody, TossPaymentConfirmResponse.class, IDEMPOTENCY_KEY);
+//        });
+//
+//        // then : RestTemplate이 총 4번 호출되었는지 검증 (최초 1회 + 재시도 3회)
+//        verify(restTemplate, times(4)).exchange(eq(URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(TossPaymentConfirmResponse.class));
+//
+//        // then : recover 내부 로직이 제대로 수행되었는지 검증
+//        verify(paymentFailLogRepository).save(any(PaymentFailLog.class));
+//        verify(paymentRepository).save(dummyPayment);
+//        verify(orderRepository).save(dummyOrder);
+//    }
+//}
+
 class IdempotentRestClientRetryRecoverTest {
 
-    @Autowired
-    private IdempotentRestClient restClient;
+    private final RestTemplate restTemplate = mock(RestTemplate.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final PaymentFailLogRepository paymentFailLogRepository = mock(PaymentFailLogRepository.class);
+    private final PaymentRepository paymentRepository = mock(PaymentRepository.class);
+    private final OrderRepository orderRepository = mock(OrderRepository.class);
 
-    @MockBean
-    private RestTemplate restTemplate;
-
-    @MockBean
-    private PaymentFailLogRepository paymentFailLogRepository;
-
-    @MockBean
-    private PaymentRepository paymentRepository;
-
-    @MockBean
-    private OrderRepository orderRepository;
-
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final IdempotentRestClient restClient = new IdempotentRestClient(
+        restTemplate,
+        objectMapper,
+        paymentFailLogRepository,
+        paymentRepository,
+        orderRepository
+    );
 
     private static final String URL = "https://api.tosspayments.com/v1/payments/confirm";
     private static final String IDEMPOTENCY_KEY = "recover-test-key";
 
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(restClient, "tossSecretKey", "test_sk");
+    }
+
     @Test
-    void externalApiFails_retryOccurs_thenRecoverExecuted() throws Exception {
-        // 외부 결제 api 호출이 실패할 때까지 retry가 3번 수행되고, 마지막에 @Recover 로직이 실행되는지
-        // given : toss 결제승인api에 보낼 request body 준비
+    void retryTemplate_retries_4_times_on_5xx_error() {
+        // given
         Map<String, Object> requestBody = Map.of(
             "paymentKey", "abc123",
             "orderId", "ORD123",
             "amount", 10000
         );
 
-        // Toss API 호출시, 항상 500에러 (retry 대상)
+        // RestTemplate이 항상 500에러 반환하게 mock
         when(restTemplate.exchange(
-            any(), eq(HttpMethod.POST), any(), eq(TossPaymentConfirmResponse.class))
+            eq(URL),
+            eq(HttpMethod.POST),
+            any(HttpEntity.class),
+            eq(TossPaymentConfirmResponse.class))
         ).thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
 
-        // recover 실행 시 필요한 설정
-        Payment dummyPayment = Payment.builder()
-            .paymentNo("1")
-            .status(PaymentStatus.WAIT)
-            .idempotencyKey(IDEMPOTENCY_KEY)
+        // RetryTemplate 구성
+        RetryTemplate template = RetryTemplate.builder()
+            .maxAttempts(4)  // 1회 시도 + 3회 재시도
+            .fixedBackoff(10)  // 10ms backoff
             .build();
 
-        Order dummyOrder = Order.builder()
-            .currentStatus(OrderStatus.PENDING)
-            .build();
-        ReflectionTestUtils.setField(dummyOrder, "id", 10L);
-
-        PaymentOrder paymentOrder = PaymentOrder.builder()
-            .order(dummyOrder)
-            .build();
-
-        dummyPayment.addPaymentOrder(paymentOrder);
-
-        when(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY))
-            .thenReturn(Optional.of(dummyPayment));
-
-        // mock를 실제 직렬화 수행
-        String json = objectMapper.writeValueAsString(requestBody);
-
-        // when : toss api 호출시, 항상 ApiException 발생
+        // when & then
         assertThrows(ApiException.class, () -> {
-            restClient.postForIdempotent(URL, requestBody, TossPaymentConfirmResponse.class, IDEMPOTENCY_KEY);
+            template.execute(context -> {
+                return restClient.postForIdempotent(URL, requestBody, TossPaymentConfirmResponse.class, IDEMPOTENCY_KEY);
+            });
         });
 
-        // then : RestTemplate이 총 4번 호출되었는지 검증 (최초 1회 + 재시도 3회)
-        verify(restTemplate, times(4)).exchange(eq(URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(TossPaymentConfirmResponse.class));
-
-        // then : recover 내부 로직이 제대로 수행되었는지 검증
-        verify(paymentFailLogRepository).save(any(PaymentFailLog.class));
-        verify(paymentRepository).save(dummyPayment);
-        verify(orderRepository).save(dummyOrder);
+        // RestTemplate이 총 4번 호출되었는지 확인
+        verify(restTemplate, times(4)).exchange(
+            eq(URL),
+            eq(HttpMethod.POST),
+            any(HttpEntity.class),
+            eq(TossPaymentConfirmResponse.class)
+        );
     }
 }

--- a/src/test/java/org/example/oshipserver/client/toss/IdempotentRestClientTest.java
+++ b/src/test/java/org/example/oshipserver/client/toss/IdempotentRestClientTest.java
@@ -1,0 +1,108 @@
+package org.example.oshipserver.client.toss;
+
+import java.util.Map;
+import org.example.oshipserver.domain.order.entity.Order;
+import org.example.oshipserver.domain.order.repository.OrderRepository;
+import org.example.oshipserver.domain.payment.dto.response.TossPaymentConfirmResponse;
+import org.example.oshipserver.domain.payment.entity.Payment;
+import org.example.oshipserver.domain.payment.entity.PaymentFailLog;
+import org.example.oshipserver.domain.payment.entity.PaymentOrder;
+import org.example.oshipserver.domain.payment.repository.PaymentFailLogRepository;
+import org.example.oshipserver.domain.payment.repository.PaymentRepository;
+import org.example.oshipserver.global.exception.ApiException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import org.example.oshipserver.domain.payment.entity.PaymentStatus;
+import org.example.oshipserver.domain.order.entity.enums.OrderStatus;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@TestPropertySource(properties = "toss.secret-key=test_sk")
+class IdempotentRestClientRetryRecoverTest {
+
+    @Autowired
+    private IdempotentRestClient restClient;
+
+    @MockBean
+    private RestTemplate restTemplate;
+
+    @MockBean
+    private PaymentFailLogRepository paymentFailLogRepository;
+
+    @MockBean
+    private PaymentRepository paymentRepository;
+
+    @MockBean
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final String URL = "https://api.tosspayments.com/v1/payments/confirm";
+    private static final String IDEMPOTENCY_KEY = "recover-test-key";
+
+    @Test
+    void externalApiFails_retryOccurs_thenRecoverExecuted() throws Exception {
+        // 외부 결제 api 호출이 실패할 때까지 retry가 3번 수행되고, 마지막에 @Recover 로직이 실행되는지
+        // given : toss 결제승인api에 보낼 request body 준비
+        Map<String, Object> requestBody = Map.of(
+            "paymentKey", "abc123",
+            "orderId", "ORD123",
+            "amount", 10000
+        );
+
+        // Toss API 호출시, 항상 500에러 (retry 대상)
+        when(restTemplate.exchange(
+            any(), eq(HttpMethod.POST), any(), eq(TossPaymentConfirmResponse.class))
+        ).thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        // recover 실행 시 필요한 설정
+        Payment dummyPayment = Payment.builder()
+            .paymentNo("1")
+            .status(PaymentStatus.WAIT)
+            .idempotencyKey(IDEMPOTENCY_KEY)
+            .build();
+
+        Order dummyOrder = Order.builder()
+            .currentStatus(OrderStatus.PENDING)
+            .build();
+        ReflectionTestUtils.setField(dummyOrder, "id", 10L);
+
+        PaymentOrder paymentOrder = PaymentOrder.builder()
+            .order(dummyOrder)
+            .build();
+
+        dummyPayment.addPaymentOrder(paymentOrder);
+
+        when(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY))
+            .thenReturn(Optional.of(dummyPayment));
+
+        // mock를 실제 직렬화 수행
+        String json = objectMapper.writeValueAsString(requestBody);
+
+        // when : toss api 호출시, 항상 ApiException 발생
+        assertThrows(ApiException.class, () -> {
+            restClient.postForIdempotent(URL, requestBody, TossPaymentConfirmResponse.class, IDEMPOTENCY_KEY);
+        });
+
+        // then : RestTemplate이 총 4번 호출되었는지 검증 (최초 1회 + 재시도 3회)
+        verify(restTemplate, times(4)).exchange(eq(URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(TossPaymentConfirmResponse.class));
+
+        // then : recover 내부 로직이 제대로 수행되었는지 검증
+        verify(paymentFailLogRepository).save(any(PaymentFailLog.class));
+        verify(paymentRepository).save(dummyPayment);
+        verify(orderRepository).save(dummyOrder);
+    }
+}

--- a/src/test/java/org/example/oshipserver/client/toss/IdempotentRestClientTest.java
+++ b/src/test/java/org/example/oshipserver/client/toss/IdempotentRestClientTest.java
@@ -30,85 +30,6 @@ import org.example.oshipserver.domain.payment.entity.PaymentStatus;
 import org.example.oshipserver.domain.order.entity.enums.OrderStatus;
 import static org.junit.jupiter.api.Assertions.*;
 
-//@SpringBootTest
-//@TestPropertySource(properties = "toss.secret-key=test_sk")
-//class IdempotentRestClientRetryRecoverTest {
-//
-//    @Autowired
-//    private IdempotentRestClient restClient;
-//
-//    @MockBean
-//    private RestTemplate restTemplate;
-//
-//    @MockBean
-//    private PaymentFailLogRepository paymentFailLogRepository;
-//
-//    @MockBean
-//    private PaymentRepository paymentRepository;
-//
-//    @MockBean
-//    private OrderRepository orderRepository;
-//
-//    @Autowired
-//    private ObjectMapper objectMapper;
-//
-//    private static final String URL = "https://api.tosspayments.com/v1/payments/confirm";
-//    private static final String IDEMPOTENCY_KEY = "recover-test-key";
-//
-//    @Test
-//    void externalApiFails_retryOccurs_thenRecoverExecuted() throws Exception {
-//        // 외부 결제 api 호출이 실패할 때까지 retry가 3번 수행되고, 마지막에 @Recover 로직이 실행되는지
-//        // given : toss 결제승인api에 보낼 request body 준비
-//        Map<String, Object> requestBody = Map.of(
-//            "paymentKey", "abc123",
-//            "orderId", "ORD123",
-//            "amount", 10000
-//        );
-//
-//        // Toss API 호출시, 항상 500에러 (retry 대상)
-//        when(restTemplate.exchange(
-//            any(), eq(HttpMethod.POST), any(), eq(TossPaymentConfirmResponse.class))
-//        ).thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
-//
-//        // recover 실행 시 필요한 설정
-//        Payment dummyPayment = Payment.builder()
-//            .paymentNo("1")
-//            .status(PaymentStatus.WAIT)
-//            .idempotencyKey(IDEMPOTENCY_KEY)
-//            .build();
-//
-//        Order dummyOrder = Order.builder()
-//            .currentStatus(OrderStatus.PENDING)
-//            .build();
-//        ReflectionTestUtils.setField(dummyOrder, "id", 10L);
-//
-//        PaymentOrder paymentOrder = PaymentOrder.builder()
-//            .order(dummyOrder)
-//            .build();
-//
-//        dummyPayment.addPaymentOrder(paymentOrder);
-//
-//        when(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY))
-//            .thenReturn(Optional.of(dummyPayment));
-//
-//        // mock를 실제 직렬화 수행
-//        String json = objectMapper.writeValueAsString(requestBody);
-//
-//        // when : toss api 호출시, 항상 ApiException 발생
-//        assertThrows(ApiException.class, () -> {
-//            restClient.postForIdempotent(URL, requestBody, TossPaymentConfirmResponse.class, IDEMPOTENCY_KEY);
-//        });
-//
-//        // then : RestTemplate이 총 4번 호출되었는지 검증 (최초 1회 + 재시도 3회)
-//        verify(restTemplate, times(4)).exchange(eq(URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(TossPaymentConfirmResponse.class));
-//
-//        // then : recover 내부 로직이 제대로 수행되었는지 검증
-//        verify(paymentFailLogRepository).save(any(PaymentFailLog.class));
-//        verify(paymentRepository).save(dummyPayment);
-//        verify(orderRepository).save(dummyOrder);
-//    }
-//}
-
 class IdempotentRestClientRetryRecoverTest {
 
     private final RestTemplate restTemplate = mock(RestTemplate.class);
@@ -135,7 +56,8 @@ class IdempotentRestClientRetryRecoverTest {
 
     @Test
     void retryTemplate_retries_4_times_on_5xx_error() {
-        // given
+
+        // given : toss 결제승인api에 보낼 request body 준비
         Map<String, Object> requestBody = Map.of(
             "paymentKey", "abc123",
             "orderId", "ORD123",
@@ -156,14 +78,14 @@ class IdempotentRestClientRetryRecoverTest {
             .fixedBackoff(10)  // 10ms backoff
             .build();
 
-        // when & then
+        // when : toss api 호출시, 항상 ApiException 발생
         assertThrows(ApiException.class, () -> {
             template.execute(context -> {
                 return restClient.postForIdempotent(URL, requestBody, TossPaymentConfirmResponse.class, IDEMPOTENCY_KEY);
             });
         });
 
-        // RestTemplate이 총 4번 호출되었는지 확인
+        // then : RestTemplate이 총 4번 호출되었는지 검증 (최초 1회 + 재시도 3회)
         verify(restTemplate, times(4)).exchange(
             eq(URL),
             eq(HttpMethod.POST),

--- a/src/test/java/org/example/oshipserver/domain/order/entity/enums/OrderStatusTest.java
+++ b/src/test/java/org/example/oshipserver/domain/order/entity/enums/OrderStatusTest.java
@@ -1,0 +1,44 @@
+package org.example.oshipserver.domain.order.entity.enums;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OrderStatusTest {
+
+    @Test
+    @DisplayName("정상 상태 전이: PENDING → PAID")
+    void testValidTransition() {
+        OrderStatus from = OrderStatus.PENDING;
+        OrderStatus to = OrderStatus.PAID;
+
+        assertDoesNotThrow(() -> from.assertTransitionTo(to));
+        assertTrue(from.canTransitionTo(to));
+    }
+
+    @Test
+    @DisplayName("정상 상태 전이: CANCELLED → REFUNDED")
+    void testValidTransition2() {
+        assertTrue(OrderStatus.CANCELLED.canTransitionTo(OrderStatus.REFUNDED));
+    }
+
+    @Test
+    @DisplayName("허용되지 않는 상태 전이: PAID → FAILED")
+    void testInvalidTransition() {
+        OrderStatus from = OrderStatus.PAID;
+        OrderStatus to = OrderStatus.FAILED;
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> from.assertTransitionTo(to));
+
+        assertEquals("주문 상태를 PAID에서 FAILED로 전이할 수 없습니다.", exception.getMessage());
+        assertFalse(from.canTransitionTo(to));
+    }
+
+    @Test
+    @DisplayName("허용되지 않는 상태 전이: REFUNDED → PENDING")
+    void testInvalidTransition2() {
+        assertFalse(OrderStatus.REFUNDED.canTransitionTo(OrderStatus.PENDING));
+    }
+}

--- a/src/test/java/org/example/oshipserver/domain/payment/entity/PaymentStatusTest.java
+++ b/src/test/java/org/example/oshipserver/domain/payment/entity/PaymentStatusTest.java
@@ -1,0 +1,46 @@
+package org.example.oshipserver.domain.payment.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PaymentStatusTest {
+
+    @Test
+    @DisplayName("정상 상태 전이: NONE → COMPLETE")
+    void testValidTransitionFromNone() {
+        assertTrue(PaymentStatus.NONE.canTransitionTo(PaymentStatus.COMPLETE));
+    }
+
+    @Test
+    @DisplayName("정상 상태 전이: WAIT → FAIL")
+    void testValidTransitionFromWait() {
+        assertTrue(PaymentStatus.WAIT.canTransitionTo(PaymentStatus.FAIL));
+    }
+
+    @Test
+    @DisplayName("정상 상태 전이: COMPLETE → CANCEL")
+    void testValidTransitionFromComplete() {
+        assertTrue(PaymentStatus.COMPLETE.canTransitionTo(PaymentStatus.CANCEL));
+    }
+
+    @Test
+    @DisplayName("정상 상태 전이: PARTIAL_CANCEL → CANCEL")
+    void testValidTransitionFromPartialCancel() {
+        assertTrue(PaymentStatus.PARTIAL_CANCEL.canTransitionTo(PaymentStatus.CANCEL));
+    }
+
+    @Test
+    @DisplayName("비정상 상태 전이: COMPLETE → WAIT")
+    void testInvalidTransition() {
+        assertFalse(PaymentStatus.COMPLETE.canTransitionTo(PaymentStatus.WAIT));
+    }
+
+    @Test
+    @DisplayName("비정상 상태 전이: CANCEL → PARTIAL_CANCEL")
+    void testInvalidTransition2() {
+        assertFalse(PaymentStatus.CANCEL.canTransitionTo(PaymentStatus.PARTIAL_CANCEL));
+    }
+
+}


### PR DESCRIPTION
## ✏️ Issue
Closes #127 

## ☑️ Todo
1. Toss API 요청 실패 시, Spring Retry로 자동 재시도
- 초기 요청 포함하여 최대 4회까지 재시도
- 재시도 간 딜레이는 2초 → 4초 → 8초로 증가

2. 모든 재시도 실패 시
- 에러 로그는 PaymentFailLog 테이블에 저장되어 관리자가 추적 가능
- 사용자에겐 TOSS_PAYMENT_FAILED 에러로 응답 처리

3. (25.06.20 리팩토링) spring retry를 통한 재결제 로직만 남겨두고, 스케줄러를 통해 재결제하는 아래의 로직들 삭제/주석처리

> - 모든 재시도 실패 시 실패 요청을 Redis List에 적재

> - RedisService를 통해 Redis에 직렬화된 요청 저장

> - 스케줄러로 Redis에서 주기적으로 실패 요청을 꺼내 재시도 실행

> - TossPaymentClient.retryPaymentConfirm(dto) 메서드로 재요청 수행

- orderStatus, paymentStatus enum 상태 전이 제약, 기존 하드코딩 메서드 수정, retry시 상태 변경 로직 추가

- 테스트 코드 작성 및 성공 : retry-recover 로직, orderStatus, paymentStatus

## ✅ Test Result
1. @Retrybale 재시도 자동 동작 확인 : 총 4회 시도(최초 + 3회 재시도)
![재처리3](https://github.com/user-attachments/assets/014a3a55-ae1a-4a71-a0f1-842276d63c3e)
![재처리3-1](https://github.com/user-attachments/assets/1e1455a0-27d9-47d5-b054-711a2528823d)
![재처리3-2](https://github.com/user-attachments/assets/9e6b430c-1429-488c-9795-12f7e61c900e)
![재처리3-3](https://github.com/user-attachments/assets/73ceae50-def3-4cb6-b58a-d520fab4f2c2)



2. api 요청 실패한 경우, 재시도 로직 실행
추가로, toss api 응답이 200ok이지만 내용이 비정상인 경우에도 재시도 유도
(응답 본문은 존재하지만 null 값으로 구성된 경우 → 내부 검증을 통해 예외 발생시키고 재시도 트리거)
![재처리3-4](https://github.com/user-attachments/assets/650f0e85-03b8-4c78-8b76-ceca3874c1b2)

3. @Recover 진입 및 상태 복구 처리
: 재시도 끝에 실패 시 @Recover 로직 진입 → 실패 로그 저장 및 결제/주문 상태 업데이트 수행
![재처리3-5](https://github.com/user-attachments/assets/9668b02d-94e2-465c-acfd-403d07e6b228)

## 💌 Reviewer Notes
