### PR TITLE
✨ [feat] #144 이메일 발송 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 	// excel
 	implementation 'org.apache.poi:poi-ooxml:5.2.3'
 
+	// Thymeleaf
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
 	// cache
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'com.github.ben-manes.caffeine:caffeine'

--- a/src/main/java/org/example/oshipserver/domain/notification/dto/NotificationRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/dto/NotificationRequest.java
@@ -1,8 +1,0 @@
-package org.example.oshipserver.domain.notification.dto;
-
-public record NotificationRequest(
-    String type,
-    String title,
-    String content,
-    Long sellerId
-) {}

--- a/src/main/java/org/example/oshipserver/domain/notification/dto/request/NotificationRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/dto/request/NotificationRequest.java
@@ -1,0 +1,10 @@
+package org.example.oshipserver.domain.notification.dto.request;
+
+import org.example.oshipserver.domain.notification.entity.NotificationType;
+
+public record NotificationRequest(
+    NotificationType type,
+    String title,
+    String content,
+    String targetEmail
+) {}

--- a/src/main/java/org/example/oshipserver/domain/notification/entity/Notification.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/entity/Notification.java
@@ -2,6 +2,8 @@ package org.example.oshipserver.domain.notification.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -28,8 +30,9 @@ public class Notification {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
-    private String type;
+    private NotificationType type;
 
     @Column(nullable = false, length = 255)
     private String title;

--- a/src/main/java/org/example/oshipserver/domain/notification/entity/NotificationType.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/entity/NotificationType.java
@@ -1,0 +1,10 @@
+package org.example.oshipserver.domain.notification.entity;
+
+public enum NotificationType {
+    ORDER_CREATED,     // 주문 생성 완료
+    ORDER_CANCELLED,   // 주문 취소
+    PAYMENT_COMPLETED, // 결제 완료
+    PAYMENT_FAILED,    // 결제 실패
+    DELIVERY_STARTED,  // 배송 시작
+    DELIVERY_COMPLETED // 배송 완료
+}

--- a/src/main/java/org/example/oshipserver/domain/notification/service/AsyncEmailNotificationService.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/service/AsyncEmailNotificationService.java
@@ -1,0 +1,19 @@
+package org.example.oshipserver.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.oshipserver.domain.notification.dto.request.NotificationRequest;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AsyncEmailNotificationService {
+
+    private final EmailNotificationService emailNotificationService;
+
+    @Async
+    public void sendAsync(NotificationRequest request) {
+        emailNotificationService.send(request);
+    }
+}
+

--- a/src/main/java/org/example/oshipserver/domain/notification/service/AsyncEmailSender.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/service/AsyncEmailSender.java
@@ -1,0 +1,18 @@
+package org.example.oshipserver.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AsyncEmailSender {
+
+    private final GmailSmtpEmailSender gmailSmtpEmailSender;
+
+    @Async
+    public void send(String to, String subject, String htmlContent) {
+        gmailSmtpEmailSender.send(to, subject, htmlContent);
+    }
+}
+

--- a/src/main/java/org/example/oshipserver/domain/notification/service/EmailNotificationService.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/service/EmailNotificationService.java
@@ -2,15 +2,9 @@ package org.example.oshipserver.domain.notification.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.oshipserver.domain.notification.dto.NotificationRequest;
+import org.example.oshipserver.domain.notification.dto.request.NotificationRequest;
 import org.example.oshipserver.domain.notification.entity.Notification;
 import org.example.oshipserver.domain.notification.repository.NotificationRepository;
-import org.example.oshipserver.domain.seller.entity.Seller;
-import org.example.oshipserver.domain.seller.repository.SellerRepository;
-import org.example.oshipserver.domain.user.entity.User;
-import org.example.oshipserver.domain.user.repository.UserRepository;
-import org.example.oshipserver.global.exception.ApiException;
-import org.example.oshipserver.global.exception.ErrorType;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -20,42 +14,36 @@ public class EmailNotificationService {
 
     private final EmailSender emailSender;
     private final NotificationRepository notificationRepository;
-    private final SellerRepository sellerRepository;
-    private final UserRepository userRepository;
+    private final EmailTemplateService emailTemplateService;
 
     public void send(NotificationRequest request) {
         Notification notification = Notification.builder()
             .type(request.type())
             .title(request.title())
             .content(request.content())
+            .targetEmail(request.targetEmail())
             .sent(false)
             .build();
 
         try {
-            Seller seller = sellerRepository.findById(request.sellerId())
-                .orElseThrow(() -> new ApiException("셀러를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
-
-            User user = userRepository.findById(seller.getUserId())
-                .orElseThrow(() -> new ApiException("유저를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
-
-            String to = user.getEmail();
-
-            emailSender.send(
-                to,
+            // content를 템플릿으로 감싸기
+            String html = emailTemplateService.renderEmail(
                 request.title(),
                 request.content()
             );
 
+            emailSender.send(
+                request.targetEmail(),
+                request.title(),
+                html
+            );
             notification.markAsSent();
-
-            // setter 추후 수정 예정
-            notification.setTargetEmail(to);
-
         } catch (Exception e) {
-            log.error("[알림 전송 실패] type={}, sellerId={}, reason={}",
-                request.type(), request.sellerId(), e.getMessage());
+            log.error("[알림 전송 실패] type={}, email={}, reason={}",
+                request.type(), request.targetEmail(), e.getMessage());
         }
 
         notificationRepository.save(notification);
     }
 }
+

--- a/src/main/java/org/example/oshipserver/domain/notification/service/EmailTemplateService.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/service/EmailTemplateService.java
@@ -1,0 +1,20 @@
+package org.example.oshipserver.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Service
+@RequiredArgsConstructor
+public class EmailTemplateService {
+
+    private final TemplateEngine templateEngine;
+
+    public String renderEmail(String title, String contentHtml) {
+        Context context = new Context();
+        context.setVariable("title", title);
+        context.setVariable("content", contentHtml);
+        return templateEngine.process("email/email", context);
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/notification/service/GmailSmtpEmailSender.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/service/GmailSmtpEmailSender.java
@@ -1,9 +1,11 @@
 package org.example.oshipserver.domain.notification.service;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -12,23 +14,22 @@ import org.springframework.stereotype.Component;
 public class GmailSmtpEmailSender implements EmailSender {
 
     private final JavaMailSender mailSender;
-
     private static final String FROM_EMAIL = "oshipapp@gmail.com";
 
     @Override
     public void send(String to, String subject, String content) {
+        MimeMessage message = mailSender.createMimeMessage();
         try {
-            SimpleMailMessage message = new SimpleMailMessage();
-            message.setTo(to);
-            message.setSubject(subject);
-            message.setText(content);
-            message.setFrom(FROM_EMAIL);
+            MimeMessageHelper helper = new MimeMessageHelper(message, "UTF-8");
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(content, true); // true → HTML로 보냄
+            helper.setFrom(FROM_EMAIL);
 
             mailSender.send(message);
-
             log.info("[Email 전송 성공] to={}, subject={}", to, subject);
 
-        } catch (Exception e) {
+        } catch (MessagingException e) {
             log.error("[Email 전송 실패] to={}, subject={}, reason={}", to, subject, e.getMessage());
             throw new RuntimeException("Gmail SMTP 메일 전송 실패", e);
         }

--- a/src/main/java/org/example/oshipserver/domain/notification/service/NotificationTemplateFactory.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/service/NotificationTemplateFactory.java
@@ -1,5 +1,0 @@
-package org.example.oshipserver.domain.notification.service;
-
-public class NotificationTemplateFactory {
-
-}

--- a/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
+++ b/src/main/java/org/example/oshipserver/domain/order/entity/Order.java
@@ -128,6 +128,7 @@ public class Order extends BaseTimeEntity {
         String serviceType,
         String packageType,
         String shippingTerm,
+        String lastTrackingEvent,
         Long sellerId
     ) {
         this.orderNo = orderNo;
@@ -144,6 +145,7 @@ public class Order extends BaseTimeEntity {
         this.serviceType = serviceType;
         this.packageType = packageType;
         this.shippingTerm = shippingTerm;
+        this.lastTrackingEvent = lastTrackingEvent;
         this.sellerId = sellerId;
         this.deleted = false;
         this.deletedBy = null;
@@ -173,6 +175,7 @@ public class Order extends BaseTimeEntity {
             .serviceType(dto.serviceType())
             .packageType(dto.packageType())
             .shippingTerm(dto.shippingTerm())
+            .lastTrackingEvent(dto.lastTrackingEvent())
             .sellerId(userId)
             .build();
     }

--- a/src/main/java/org/example/oshipserver/domain/order/service/OrderNotificationService.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/OrderNotificationService.java
@@ -1,0 +1,50 @@
+package org.example.oshipserver.domain.order.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.oshipserver.domain.notification.dto.request.NotificationRequest;
+import org.example.oshipserver.domain.notification.entity.NotificationType;
+import org.example.oshipserver.domain.notification.service.AsyncEmailNotificationService;
+import org.example.oshipserver.domain.notification.service.EmailNotificationService;
+import org.example.oshipserver.domain.order.entity.Order;
+import org.example.oshipserver.domain.seller.entity.Seller;
+import org.example.oshipserver.domain.seller.repository.SellerRepository;
+import org.example.oshipserver.domain.user.entity.User;
+import org.example.oshipserver.domain.user.repository.UserRepository;
+import org.example.oshipserver.global.exception.ApiException;
+import org.example.oshipserver.global.exception.ErrorType;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderNotificationService {
+
+    private final SellerRepository sellerRepository;
+    private final UserRepository userRepository;
+    private final EmailNotificationService emailNotificationService;         // 동기
+    private final AsyncEmailNotificationService asyncEmailNotificationService; // 비동기
+
+    public void sendOrderCreatedSync(Order order) {
+        NotificationRequest request = buildNotificationRequest(order);
+        emailNotificationService.send(request);
+    }
+
+    public void sendOrderCreatedAsync(Order order) {
+        NotificationRequest request = buildNotificationRequest(order);
+        asyncEmailNotificationService.sendAsync(request);
+    }
+
+    private NotificationRequest buildNotificationRequest(Order order) {
+        Seller seller = sellerRepository.findById(order.getSellerId())
+            .orElseThrow(() -> new ApiException("셀러 없음", ErrorType.NOT_FOUND));
+
+        User user = userRepository.findById(seller.getUserId())
+            .orElseThrow(() -> new ApiException("유저 없음", ErrorType.NOT_FOUND));
+
+        return new NotificationRequest(
+            NotificationType.ORDER_CREATED,
+            "[OSH] 주문 생성 알림",
+            "주문번호 " + order.getOrderNo() + "가 생성되었습니다.",
+            user.getEmail()
+        );
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/order/service/OrderService.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/OrderService.java
@@ -39,6 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OrderService {
     private final OrderRepository orderRepository;
+    private final OrderNotificationService orderNotificationService;
     private final TrackingEventHandler trackingEventHandler;
 
     public String createOrder(Long userId, OrderCreateRequest orderCreateRequest) {
@@ -122,7 +123,13 @@ public class OrderService {
             ""
         );
 
-        // 9. 알림 전송 (이메일 발송)
+//        9. 알림 전송 (이메일 발송)
+//        동기 호출
+//        orderNotificationService.sendOrderCreatedSync(order);
+//
+//        비동기 호출
+//        orderNotificationService.sendOrderCreatedAsync(order);
+
 
         return masterNo;
     }

--- a/src/main/java/org/example/oshipserver/global/config/AsyncConfig.java
+++ b/src/main/java/org/example/oshipserver/global/config/AsyncConfig.java
@@ -1,0 +1,16 @@
+package org.example.oshipserver.global.config;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean
+    public Executor taskExecutor() {
+        return Executors.newCachedThreadPool();
+    }
+}

--- a/src/main/resources/templates/email/email.html
+++ b/src/main/resources/templates/email/email.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    body { font-family: Arial, sans-serif; background-color: #f7f7f7; padding: 20px; }
+    .container { max-width: 600px; margin: 0 auto; background: #ffffff; padding: 30px; border-radius: 8px; border: 1px solid #ddd; }
+    .title { font-size: 20px; font-weight: bold; margin-bottom: 15px; }
+    .content { font-size: 14px; line-height: 1.6; }
+    .footer { margin-top: 30px; font-size: 12px; color: #888888; text-align: center; }
+  </style>
+</head>
+<body>
+<div class="container">
+  <div class="title" th:text="${title}">알림 제목</div>
+  <div class="content" th:utext="${content}">여기에 알림 본문이 들어갑니다.</div>
+  <div class="footer">
+    ⓒ OSHIP 플랫폼<br/>
+    이 메일은 자동 발송되었습니다.
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## ✏️ Issue

Closes #144 

## ☑️ Todo

- 이메일 템플릿 렌더링을 위한 `EmailTemplateService` 구현 (Thymeleaf 연동)
- `EmailNotificationService`를 통해 알림 전송 및 실패 예외 처리
- `@Async` 기반의 `AsyncEmailNotificationService` 도입으로 비동기 전송 처리
- `OrderNotificationService`에서 주문 생성 시 사용자에게 메일 알림 자동 전송
- 주문 생성 시 이메일 발송 트리거는 order 도메인에서 분리 (OrderNotificationService)

메일을 보낼 상태값을 Enum 으로 정리해뒀는데 관련해서 더 추가할 내용이 생긴다면 여기에 추가해주셔도 좋을 것 같습니다 ~
https://github.com/oship-management/oship-be/blob/8dc30100132fc3bd6be180724d27a7dcef663be8/src/main/java/org/example/oshipserver/domain/notification/entity/NotificationType.java#L3-L9

### ⚙️ 이메일 전송 설계

- HTML 기반 메일 본문을 Thymeleaf 템플릿(`email/email.html`)으로 구성
- 메일 전송 성공/실패 여부는 `Notification` 엔티티에 기록
- `@Async`를 통해 메일 전송을 비동기 처리 → 클라이언트 응답 지연 방지

🔎 **동기 방식과 비동기 방식의 차이**

| 항목 | 동기(Sync) | 비동기(Async with `@Async`) |
| --- | --- | --- |
| **로그 출력 시점** | 메일 전송 완료 후 로그 출력 | 메일 전송 전에 응답 반환 → 이후 백그라운드에서 로그 출력 |
| **Postman 응답 대기 시간** | 느림 (메일 전송 완료까지 대기) | 빠름 (메일 전송과 관계없이 즉시 응답) |
| **메일 전송 순서** | 호출 → 전송 → 응답 | 호출 → 응답 반환 → 전송 (백그라운드) |
| **예외 발생 시 응답** | 응답에 반영됨 | 응답에는 반영되지 않음 (로그만 출력) |


## ✅ Test Result

동기 호출 시 약 4.8초 소요
![image](https://github.com/user-attachments/assets/a694a835-84b1-43f0-8783-3aa45297a8a2)

비동기 호출 시 약 0.2 초 소요
![image](https://github.com/user-attachments/assets/e3f4da23-4ffe-4efe-b4c9-4df91ba12475)

Thymeleaf 연동 전 후
![image](https://github.com/user-attachments/assets/81675f02-8c94-4a3b-a2cc-84b53f4bba2b)

![image](https://github.com/user-attachments/assets/bc237192-450a-4180-9208-4736724a6b71)

## 💌 Reviewer Notes

메일 전송 로직은 notification 도메인에 집중시켜 재사용성과 확장성을 고려했습니다.
각 도메인(order, delivery 등)에서는 자신의 이벤트 발생 시 알림 전송 책임만 분리 위임하는 구조로 구성되어 있습니다.

현재는 직접 호출 방식이지만, 이후 도메인 이벤트 기반 아키텍처로 확장할 수도 있을 것 같아요 ... 
월요일에 튜터님들 찾아뵙고 조언을 구할 것 같습니다 .. !!
Redis 큐 기반 전송 구조로 확장할까 고민중에 있고, NotificationSendHistory도 추가할 것 같습니다.