### PR TITLE
✨ [feat] #147 이메일 전송 Redis 큐 처리

### DIFF
--- a/src/main/java/org/example/oshipserver/OshipServerApplication.java
+++ b/src/main/java/org/example/oshipserver/OshipServerApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @EnableCaching
+@EnableScheduling
 @SpringBootApplication
 public class OshipServerApplication {
 

--- a/src/main/java/org/example/oshipserver/domain/log/service/LogService.java
+++ b/src/main/java/org/example/oshipserver/domain/log/service/LogService.java
@@ -2,14 +2,14 @@ package org.example.oshipserver.domain.log.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class LogService {
-    private final RedisTemplate<String, String> redisTemplate;
+    private final StringRedisTemplate redisTemplate;
 
     public void sendLogToRedis(String logJson) {
         log.info(logJson);

--- a/src/main/java/org/example/oshipserver/domain/notification/dto/message/EmailNotificationMessage.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/dto/message/EmailNotificationMessage.java
@@ -4,5 +4,6 @@ public record EmailNotificationMessage(
     String email,
     String subject,
     String content,
-    int retryCount
+    int retryCount,
+    Long notificationId
 ) {}

--- a/src/main/java/org/example/oshipserver/domain/notification/dto/message/EmailNotificationMessage.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/dto/message/EmailNotificationMessage.java
@@ -1,0 +1,8 @@
+package org.example.oshipserver.domain.notification.dto.message;
+
+public record EmailNotificationMessage(
+    String email,
+    String subject,
+    String content,
+    int retryCount
+) {}

--- a/src/main/java/org/example/oshipserver/domain/notification/service/EmailNotificationConsumer.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/service/EmailNotificationConsumer.java
@@ -1,0 +1,70 @@
+package org.example.oshipserver.domain.notification.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.oshipserver.domain.notification.dto.message.EmailNotificationMessage;
+import org.example.oshipserver.domain.notification.repository.NotificationRepository;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailNotificationConsumer {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final EmailSender emailSender;
+    private final NotificationRepository notificationRepository;
+
+    private static final String QUEUE_NAME = "email-notification-queue";
+    private static final String DLQ_NAME = "email-notification-dlq";
+
+    @Scheduled(fixedDelay = 2000)
+    public void pollAndSendEmail() {
+        String json = redisTemplate.opsForList().rightPop(QUEUE_NAME);
+        if (json == null) return;
+
+        try {
+            EmailNotificationMessage message = objectMapper.readValue(json, EmailNotificationMessage.class);
+
+            emailSender.send(message.email(), message.subject(), message.content());
+            log.info("[이메일 전송 성공] to={}, subject={}", message.email(), message.subject());
+
+            // 전송 성공 시 Notification 업데이트
+            if (message.notificationId() != null) {
+                notificationRepository.findById(message.notificationId())
+                    .ifPresent(notification -> {
+                        notification.markAsSent();
+                        notificationRepository.save(notification);
+                    });
+            }
+
+        } catch (Exception e) {
+            handleRetry(json);
+        }
+    }
+
+    private void handleRetry(String json) {
+        try {
+            EmailNotificationMessage msg = objectMapper.readValue(json, EmailNotificationMessage.class);
+            int retry = msg.retryCount() + 1;
+
+            if (retry < 3) {
+                EmailNotificationMessage retryMsg = new EmailNotificationMessage(
+                    msg.email(), msg.subject(), msg.content(), retry, msg.notificationId()
+                );
+                redisTemplate.opsForList().leftPush(QUEUE_NAME, objectMapper.writeValueAsString(retryMsg));
+                log.warn("[이메일 재시도] {}회 → to={}", retry, msg.email());
+            } else {
+                redisTemplate.opsForList().leftPush(DLQ_NAME, json);
+                log.error("[이메일 전송 실패 - DLQ 이동] to={}, subject={}", msg.email(), msg.subject());
+            }
+        } catch (Exception ex) {
+            log.error("[DLQ 처리 중 에러] {}", ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/notification/service/EmailNotificationProducer.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/service/EmailNotificationProducer.java
@@ -1,0 +1,38 @@
+package org.example.oshipserver.domain.notification.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.example.oshipserver.domain.notification.dto.message.EmailNotificationMessage;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class EmailNotificationProducer {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private static final String QUEUE_NAME = "email-notification-queue";
+
+    public EmailNotificationProducer(
+        @Qualifier("stringQueueRedisTemplate") RedisTemplate<String, String> redisTemplate,
+        ObjectMapper objectMapper
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public void send(EmailNotificationMessage message) {
+        try {
+            String json = objectMapper.writeValueAsString(message);
+            redisTemplate.opsForList().leftPush(QUEUE_NAME, json);
+            log.info("[Redis 큐 적재 성공] key={}, value={}", QUEUE_NAME, json);
+        } catch (JsonProcessingException e) {
+            log.error("[Redis 큐 직렬화 실패] {}", e.getMessage());
+            throw new RuntimeException("Email 메시지 직렬화 실패", e);
+        }
+    }
+}
+

--- a/src/main/java/org/example/oshipserver/domain/notification/service/EmailNotificationService.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/service/EmailNotificationService.java
@@ -2,6 +2,7 @@ package org.example.oshipserver.domain.notification.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.oshipserver.domain.notification.dto.message.EmailNotificationMessage;
 import org.example.oshipserver.domain.notification.dto.request.NotificationRequest;
 import org.example.oshipserver.domain.notification.entity.Notification;
 import org.example.oshipserver.domain.notification.repository.NotificationRepository;
@@ -12,11 +13,13 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class EmailNotificationService {
 
-    private final EmailSender emailSender;
     private final NotificationRepository notificationRepository;
     private final EmailTemplateService emailTemplateService;
+    private final EmailNotificationProducer emailNotificationProducer;
 
     public void send(NotificationRequest request) {
+
+        // 1. Notification 저장 (ID 확보)
         Notification notification = Notification.builder()
             .type(request.type())
             .title(request.title())
@@ -24,26 +27,28 @@ public class EmailNotificationService {
             .targetEmail(request.targetEmail())
             .sent(false)
             .build();
+        notificationRepository.save(notification);
 
         try {
-            // content를 템플릿으로 감싸기
+            // 2. 템플릿 변환 + 메시지 생성
             String html = emailTemplateService.renderEmail(
                 request.title(),
                 request.content()
             );
 
-            emailSender.send(
+            EmailNotificationMessage message = new EmailNotificationMessage(
                 request.targetEmail(),
                 request.title(),
-                html
+                html,
+                0,
+                notification.getId()
             );
-            notification.markAsSent();
-        } catch (Exception e) {
-            log.error("[알림 전송 실패] type={}, email={}, reason={}",
-                request.type(), request.targetEmail(), e.getMessage());
-        }
 
-        notificationRepository.save(notification);
+            // 3. Redis 큐에 push
+            emailNotificationProducer.send(message);
+
+        } catch (Exception e) {
+            log.error("[Producer 전송 실패] email={}, reason={}", request.targetEmail(), e.getMessage());
+        }
     }
 }
-

--- a/src/main/java/org/example/oshipserver/domain/order/service/OrderNotificationService.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/OrderNotificationService.java
@@ -1,10 +1,16 @@
 package org.example.oshipserver.domain.order.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.oshipserver.domain.notification.dto.message.EmailNotificationMessage;
 import org.example.oshipserver.domain.notification.dto.request.NotificationRequest;
+import org.example.oshipserver.domain.notification.entity.Notification;
 import org.example.oshipserver.domain.notification.entity.NotificationType;
+import org.example.oshipserver.domain.notification.repository.NotificationRepository;
 import org.example.oshipserver.domain.notification.service.AsyncEmailNotificationService;
+import org.example.oshipserver.domain.notification.service.EmailNotificationProducer;
 import org.example.oshipserver.domain.notification.service.EmailNotificationService;
+import org.example.oshipserver.domain.notification.service.EmailTemplateService;
 import org.example.oshipserver.domain.order.entity.Order;
 import org.example.oshipserver.domain.seller.entity.Seller;
 import org.example.oshipserver.domain.seller.repository.SellerRepository;
@@ -14,6 +20,7 @@ import org.example.oshipserver.global.exception.ApiException;
 import org.example.oshipserver.global.exception.ErrorType;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrderNotificationService {
@@ -22,6 +29,9 @@ public class OrderNotificationService {
     private final UserRepository userRepository;
     private final EmailNotificationService emailNotificationService;         // 동기
     private final AsyncEmailNotificationService asyncEmailNotificationService; // 비동기
+    private final EmailNotificationProducer emailNotificationProducer;
+    private final EmailTemplateService emailTemplateService;
+    private final NotificationRepository notificationRepository;
 
     public void sendOrderCreatedSync(Order order) {
         NotificationRequest request = buildNotificationRequest(order);
@@ -31,6 +41,46 @@ public class OrderNotificationService {
     public void sendOrderCreatedAsync(Order order) {
         NotificationRequest request = buildNotificationRequest(order);
         asyncEmailNotificationService.sendAsync(request);
+    }
+
+    public void sendOrderCreatedV2(Order order) {
+        Seller seller = sellerRepository.findById(order.getSellerId())
+            .orElseThrow(() -> new ApiException("셀러 없음", ErrorType.NOT_FOUND));
+
+        User user = userRepository.findById(seller.getUserId())
+            .orElseThrow(() -> new ApiException("유저 없음", ErrorType.NOT_FOUND));
+
+        String subject = "[OSH] 주문 생성 알림";
+        String content = "주문번호 " + order.getOrderNo() + "가 생성되었습니다.";
+
+        // 1. Notification 엔티티 생성 및 저장
+        Notification notification = Notification.builder()
+            .type(NotificationType.ORDER_CREATED)
+            .title(subject)
+            .content(content)
+            .targetEmail(user.getEmail())
+            .sent(false)
+            .build();
+        notificationRepository.save(notification);
+
+        // 2. 이메일 HTML 본문 생성
+        try {
+            String html = emailTemplateService.renderEmail(subject, content);
+
+            // 3. Redis 큐 전송
+            EmailNotificationMessage message = new EmailNotificationMessage(
+                user.getEmail(),
+                subject,
+                html,
+                0,
+                notification.getId() // Notification과 연동된 메시지
+            );
+            emailNotificationProducer.send(message);
+        } catch (Exception e) {
+            // 템플릿 렌더링 실패 시 로그만 남기고 전송 생략
+            log.error("[알림 템플릿 렌더링 실패] orderNo={}, email={}, reason={}",
+                order.getOrderNo(), user.getEmail(), e.getMessage());
+        }
     }
 
     private NotificationRequest buildNotificationRequest(Order order) {

--- a/src/main/java/org/example/oshipserver/domain/order/service/OrderService.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/OrderService.java
@@ -1,6 +1,6 @@
 package org.example.oshipserver.domain.order.service;
 
-import static org.example.oshipserver.global.config.RedisCacheConfig.CURRENT_MONTH_CACHE;
+import static org.example.oshipserver.global.config.redis.RedisCacheConfig.CURRENT_MONTH_CACHE;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -130,7 +130,8 @@ public class OrderService {
 //        비동기 호출
 //        orderNotificationService.sendOrderCreatedAsync(order);
 
-
+//        V2 큐 기반 비동기 이메일 전송
+//        orderNotificationService.sendOrderCreatedV2(order);
         return masterNo;
     }
 

--- a/src/main/java/org/example/oshipserver/domain/order/service/stats/OrderStatsCacheService.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/stats/OrderStatsCacheService.java
@@ -1,7 +1,7 @@
 package org.example.oshipserver.domain.order.service.stats;
 
-import static org.example.oshipserver.global.config.RedisCacheConfig.CURRENT_MONTH_CACHE;
-import static org.example.oshipserver.global.config.RedisCacheConfig.PAST_MONTH_CACHE;
+import static org.example.oshipserver.global.config.redis.RedisCacheConfig.CURRENT_MONTH_CACHE;
+import static org.example.oshipserver.global.config.redis.RedisCacheConfig.PAST_MONTH_CACHE;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;

--- a/src/main/java/org/example/oshipserver/global/config/redis/RedisCacheConfig.java
+++ b/src/main/java/org/example/oshipserver/global/config/redis/RedisCacheConfig.java
@@ -1,4 +1,4 @@
-package org.example.oshipserver.global.config;
+package org.example.oshipserver.global.config.redis;
 
 import java.time.Duration;
 import java.util.HashMap;

--- a/src/main/java/org/example/oshipserver/global/config/redis/RedisConfig.java
+++ b/src/main/java/org/example/oshipserver/global/config/redis/RedisConfig.java
@@ -1,4 +1,4 @@
-package org.example.oshipserver.global.config;
+package org.example.oshipserver.global.config.redis;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/org/example/oshipserver/global/config/redis/RedisQueueConfig.java
+++ b/src/main/java/org/example/oshipserver/global/config/redis/RedisQueueConfig.java
@@ -1,0 +1,27 @@
+package org.example.oshipserver.global.config.redis;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * 이메일 큐 전용 RedisTemplate 설정
+ * Key: String, Value: String (JSON 문자열 저장)
+ */
+@Configuration
+public class RedisQueueConfig {
+
+    @Bean(name = "stringQueueRedisTemplate")
+    public RedisTemplate<String, String> stringQueueRedisTemplate(
+        @Qualifier("redisConnectionFactory") RedisConnectionFactory connectionFactory
+    ) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}


### PR DESCRIPTION
## ✏️ Issue

Closes #147

## ☑️ Todo
- [ ]  Redis 큐 발송용 `EmailNotificationProducer` 구현
- [ ]  `LogService`, `EmailNotificationProducer`의 다중 Bean 충돌 해결 (`@Qualifier` 사용)

>  실패 메시지의 재시도(Consumer 처리)는 아직 구현되지 않았습니다.
> 추후 PR에 포함 예정입니다.

## ✅ Test Result
* Redis 큐에 정상적으로 메일 전송 요청 적재 여부는 확인 전 -> 추후 확인 예정
* EmailConsumer 동작 및 SMTP 메일 발송도 정상 작동함 (Postman + 콘솔 로그 기반 확인)

## 💌 Reviewer Notes
* 추후 실패 시 큐에 남겨두고 재시도 로직을 추가할 예정입니다