### PR TITLE
♻️ [refactor] 파트너 측정 값 기준으로 요금결정

### DIFF
--- a/src/main/java/org/example/oshipserver/client/fedex/FedexRestTemplateConfig.java
+++ b/src/main/java/org/example/oshipserver/client/fedex/FedexRestTemplateConfig.java
@@ -17,8 +17,8 @@ import org.springframework.web.client.RestTemplate;
 public class FedexRestTemplateConfig {
 
     // 타임아웃 상수 정의
-    private static final int CONNECT_TIMEOUT_MS = 30000;           // 30초
-    private static final int CONNECTION_REQUEST_TIMEOUT_MS = 30000; // 30초
+    private static final int CONNECT_TIMEOUT_MS = 60000;           // 60초
+    private static final int CONNECTION_REQUEST_TIMEOUT_MS = 60000; // 60초
     private static final int HTTP_STATUS_BAD_REQUEST = 400;
     private static final int HTTP_STATUS_UNAUTHORIZED = 401;
 

--- a/src/main/java/org/example/oshipserver/domain/carrier/repository/CarrierRateChargeRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/carrier/repository/CarrierRateChargeRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CarrierRateChargeRepository extends JpaRepository<CarrierRateCharge, Long> {
+public interface CarrierRateChargeRepository extends JpaRepository<CarrierRateCharge, Long>, CarrierRateChargeRepositoryCustom {
 
     @Modifying(clearAutomatically = true)
     @Query("""

--- a/src/main/java/org/example/oshipserver/domain/carrier/repository/CarrierRateChargeRepositoryCustom.java
+++ b/src/main/java/org/example/oshipserver/domain/carrier/repository/CarrierRateChargeRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.example.oshipserver.domain.carrier.repository;
+
+import org.example.oshipserver.domain.order.entity.enums.CountryCode;
+
+import java.math.BigDecimal;
+
+public interface CarrierRateChargeRepositoryCustom {
+    BigDecimal findChargeByCarrierAndWeightAndCountry(Long carrierId, BigDecimal weight, CountryCode countryCode);
+}

--- a/src/main/java/org/example/oshipserver/domain/carrier/repository/CarrierRateChargeRepositoryImpl.java
+++ b/src/main/java/org/example/oshipserver/domain/carrier/repository/CarrierRateChargeRepositoryImpl.java
@@ -1,0 +1,56 @@
+package org.example.oshipserver.domain.carrier.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.oshipserver.domain.carrier.entity.QCarrier;
+import org.example.oshipserver.domain.carrier.entity.QCarrierCountry;
+import org.example.oshipserver.domain.carrier.entity.QCarrierRateCharge;
+import org.example.oshipserver.domain.order.entity.enums.CountryCode;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Repository
+@RequiredArgsConstructor
+public class CarrierRateChargeRepositoryImpl implements CarrierRateChargeRepositoryCustom {
+    
+    private final JPAQueryFactory queryFactory;
+    
+    @Override
+    public BigDecimal findChargeByCarrierAndWeightAndCountry(Long carrierId, BigDecimal weight, CountryCode countryCode) {
+        QCarrierRateCharge carrierRateCharge = QCarrierRateCharge.carrierRateCharge;
+        QCarrier carrier = QCarrier.carrier;
+        QCarrierCountry carrierCountry = QCarrierCountry.carrierCountry;
+        
+        // 먼저 해당 carrier와 country에 대한 zoneNo를 조회
+        Integer zoneNo = queryFactory
+            .select(carrierCountry.zoneNo)
+            .from(carrierCountry)
+            .where(
+                carrierCountry.carrier.id.eq(carrierId),
+                carrierCountry.countryCode.eq(countryCode)
+            )
+            .fetchOne();
+        
+        if (zoneNo == null) {
+            return BigDecimal.ZERO;
+        }
+        
+        // zoneNo를 사용하여 요금 조회
+        BigDecimal amount = queryFactory
+            .select(carrierRateCharge.amount)
+            .from(carrierRateCharge)
+            .join(carrierRateCharge.carrier, carrier)
+            .where(
+                carrierRateCharge.carrier.id.eq(carrierId),
+                carrierRateCharge.weight.eq(weight),
+                carrierRateCharge.zoneIndex.eq(zoneNo),
+                carrierRateCharge.deletedAt.isNull(),
+                carrier.expired.after(LocalDateTime.now())
+            )
+            .fetchOne();
+        
+        return amount != null ? amount : BigDecimal.ZERO;
+    }
+}

--- a/src/main/java/org/example/oshipserver/domain/partner/repository/PartnerRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/partner/repository/PartnerRepository.java
@@ -3,8 +3,11 @@ package org.example.oshipserver.domain.partner.repository;
 import org.example.oshipserver.domain.partner.entity.Partner;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PartnerRepository extends JpaRepository<Partner, Long>, IPartnerRepository {
 
-
     boolean existsByCompanyRegisterNo(String companyRegisterNo);
+    
+    Optional<Partner> findByUserId(Long userId);
 }

--- a/src/main/java/org/example/oshipserver/domain/shipping/dto/request/ShipmentMeasureRequest.java
+++ b/src/main/java/org/example/oshipserver/domain/shipping/dto/request/ShipmentMeasureRequest.java
@@ -1,11 +1,28 @@
 package org.example.oshipserver.domain.shipping.dto.request;
 
+import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
 public record ShipmentMeasureRequest(
-    @DecimalMin("1") BigDecimal width,
-    @DecimalMin("1") BigDecimal height,
-    @DecimalMin("1") BigDecimal length,
-    @DecimalMin("0.1") BigDecimal grossWeight
+    @NotNull(message = "Width is required")
+    @DecimalMin(value = "1", message = "Width must be at least 1cm")
+    @DecimalMax(value = "120", message = "Width must not exceed 120cm")
+    BigDecimal width,
+    
+    @NotNull(message = "Height is required")
+    @DecimalMin(value = "1", message = "Height must be at least 1cm")
+    @DecimalMax(value = "120", message = "Height must not exceed 120cm")
+    BigDecimal height,
+    
+    @NotNull(message = "Length is required")
+    @DecimalMin(value = "1", message = "Length must be at least 1cm")
+    @DecimalMax(value = "120", message = "Length must not exceed 120cm")
+    BigDecimal length,
+    
+    @NotNull(message = "Gross weight is required")
+    @DecimalMin(value = "0.1", message = "Weight must be at least 0.1kg")
+    @DecimalMax(value = "9999", message = "Weight must not exceed 9999kg")
+    BigDecimal grossWeight
 ) {}

--- a/src/main/java/org/example/oshipserver/domain/shipping/entity/Shipment.java
+++ b/src/main/java/org/example/oshipserver/domain/shipping/entity/Shipment.java
@@ -43,7 +43,7 @@ public class Shipment extends BaseTimeEntity {
     @Column(name = "gross_weight", precision = 20, scale = 2)
     private BigDecimal grossWeight;
 
-    @Column(name = "volumn_weight", precision = 20, scale = 2)
+    @Column(name = "volume_weight", precision = 20, scale = 2)
     private BigDecimal volumeWeight;
 
     @Column(name = "charge_weight", precision = 20, scale = 2)

--- a/src/main/java/org/example/oshipserver/domain/shipping/entity/Shipment.java
+++ b/src/main/java/org/example/oshipserver/domain/shipping/entity/Shipment.java
@@ -111,4 +111,14 @@ public class Shipment extends BaseTimeEntity {
         this.awbUrl = awbUrl;
         this.carrierTrackingNo = carrierTrackingNo;
     }
+    
+    // 부피 무게 설정 메서드
+    public void updateVolumeWeight(BigDecimal volumeWeight) {
+        this.volumeWeight = volumeWeight;
+    }
+    
+    // 요금 설정 메서드
+    public void updateChargeValue(BigDecimal chargeValue) {
+        this.chargeValue = chargeValue;
+    }
 }

--- a/src/main/java/org/example/oshipserver/domain/shipping/service/ShipmentService.java
+++ b/src/main/java/org/example/oshipserver/domain/shipping/service/ShipmentService.java
@@ -1,9 +1,12 @@
 package org.example.oshipserver.domain.shipping.service;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import lombok.RequiredArgsConstructor;
 import org.example.oshipserver.client.fedex.FedexClient;
 import org.example.oshipserver.client.fedex.FedexShipmentResponse;
 import org.example.oshipserver.domain.carrier.entity.Carrier;
+import org.example.oshipserver.domain.carrier.repository.CarrierRateChargeRepository;
 import org.example.oshipserver.domain.carrier.repository.CarrierRepository;
 import org.example.oshipserver.domain.order.entity.Order;
 import org.example.oshipserver.domain.order.repository.OrderRepository;
@@ -25,6 +28,7 @@ public class ShipmentService {
 
     private final ShipmentRepository shipmentRepository;
     private final CarrierRepository carrierRepository;
+    private final CarrierRateChargeRepository carrierRateChargeRepository;
     private final OrderRepository orderRepository;
     private final TrackingEventHandler trackingEventHandler;
     private final FedexClient fedexClient;
@@ -72,32 +76,40 @@ public class ShipmentService {
             throw new ApiException("이미 AWB가 발행된 배송입니다.", ErrorType.AWB_ALREADY_ISSUED);
         }
 
-        // 4. 측정 정보 업데이트
+        // 4. 부피 무게 계산 (가로 × 세로 × 높이) / 5000
+        BigDecimal volumeWeight = calculateVolumeWeight(request.width(), request.height(), request.length());
+        
+        // 5. 측정 정보 업데이트 (부피 무게 포함)
         shipment.updateMeasurements(
             request.width(),
             request.height(),
             request.length(),
             request.grossWeight()
         );
+        shipment.updateVolumeWeight(volumeWeight);
+        
+        // 6. 요금 계산
+        BigDecimal chargeValue = calculateShippingCharge(shipment, order);
+        shipment.updateChargeValue(chargeValue);
 
-        // 5. AWB URL 생성
+        // 7. AWB URL 생성
         FedexShipmentResponse fedexResponse = fedexClient.requestAwbLabelUrl(shipment, order, request);
         shipment.updateAwb(fedexResponse.labelUrl(), fedexResponse.carrierTrackingNo());
 
-        // 6. 저장
+        // 8. 저장
         shipmentRepository.save(shipment);
 
-        // 7. AWB 생성 트래킹 이벤트 추가
+        // 9. AWB 생성 트래킹 이벤트 추가
         trackingEventHandler.handleTrackingEvent(
             order.getId(),
             TrackingEventEnum.AWB_CREATED,
             ""
         );
 
-        // 8. OrderTable AWB 생성 완료 처리
+        // 10. OrderTable AWB 생성 완료 처리
         order.markAwbGenerated();
 
-        // 9. 응답 데이터 생성 (Builder 패턴 사용)
+        // 11. 응답 데이터 생성 (Builder 패턴 사용)
         AwbResponse.MeasurementData measurements = AwbResponse.MeasurementData.builder()
             .width(request.width())
             .height(request.height())
@@ -115,5 +127,40 @@ public class ShipmentService {
         return AwbResponse.builder()
             .shipment(shipmentData)
             .build();
+    }
+    
+    /**
+     * 부피 무게 계산: (가로 × 세로 × 높이) / 5000
+     */
+    private BigDecimal calculateVolumeWeight(BigDecimal width, BigDecimal height, BigDecimal length) {
+        if (width == null || height == null || length == null) {
+            return BigDecimal.ZERO;
+        }
+        
+        BigDecimal volume = width.multiply(height).multiply(length);
+        return volume.divide(new BigDecimal("5000"), 2, RoundingMode.HALF_UP);
+    }
+    
+    /**
+     * 배송 요금 계산
+     */
+    private BigDecimal calculateShippingCharge(Shipment shipment, Order order) {
+        // 실제 무게와 부피 무게 중 큰 값 사용
+        BigDecimal actualWeight = shipment.getGrossWeight() != null ? shipment.getGrossWeight() : BigDecimal.ZERO;
+        BigDecimal volumeWeight = shipment.getVolumeWeight() != null ? shipment.getVolumeWeight() : BigDecimal.ZERO;
+        BigDecimal chargeableWeight = actualWeight.compareTo(volumeWeight) > 0 ? actualWeight : volumeWeight;
+        
+        // 0.5kg 단위로 올림 (20kg 미만인 경우)
+        if (chargeableWeight.compareTo(new BigDecimal("20")) < 0) {
+            BigDecimal halfKg = new BigDecimal("0.5");
+            chargeableWeight = chargeableWeight.divide(halfKg, 0, RoundingMode.UP).multiply(halfKg);
+        }
+        
+        // QueryDSL로 요금 조회
+        return carrierRateChargeRepository.findChargeByCarrierAndWeightAndCountry(
+            shipment.getCarrierId(),
+            chargeableWeight,
+            order.getRecipient().getRecipientAddress().getRecipientCountryCode()
+        );
     }
 }

--- a/src/main/java/org/example/oshipserver/global/config/SchedulerConfig.java
+++ b/src/main/java/org/example/oshipserver/global/config/SchedulerConfig.java
@@ -1,0 +1,22 @@
+package org.example.oshipserver.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+public class SchedulerConfig implements SchedulingConfigurer {
+    
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+        threadPoolTaskScheduler.setPoolSize(5);
+        threadPoolTaskScheduler.setThreadNamePrefix("scheduled-task-");
+        threadPoolTaskScheduler.setWaitForTasksToCompleteOnShutdown(true);
+        threadPoolTaskScheduler.setAwaitTerminationSeconds(60);
+        threadPoolTaskScheduler.initialize();
+        
+        taskRegistrar.setTaskScheduler(threadPoolTaskScheduler);
+    }
+}

--- a/src/test/java/org/example/oshipserver/domain/auth/AuthIntegrationTest.java
+++ b/src/test/java/org/example/oshipserver/domain/auth/AuthIntegrationTest.java
@@ -33,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ExtendWith(SpringExtension.class)
-class AuthIntergrationTest {
+class AuthIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/org/example/oshipserver/domain/partner/PartnerIntegrationTest.java
+++ b/src/test/java/org/example/oshipserver/domain/partner/PartnerIntegrationTest.java
@@ -37,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ExtendWith(SpringExtension.class)
-public class PartnerIntergrationTest {
+public class PartnerIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/org/example/oshipserver/domain/seller/SellerIntegrationTest.java
+++ b/src/test/java/org/example/oshipserver/domain/seller/SellerIntegrationTest.java
@@ -38,7 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ExtendWith(SpringExtension.class)
-public class SellerIntergrationTest {
+public class SellerIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## ✏️ Issue
Closes #162 

## ☑️ Todo
  1. QueryDSL 기반 Repository 구조 생성:
    - CarrierRateChargeRepositoryCustom 인터페이스 생성
    - CarrierRateChargeRepositoryImpl 구현체 생성
    - CarrierRateChargeRepository가 Custom 인터페이스를 상속
  2. QueryDSL 구현:
    - 두 단계로 쿼리 실행:
        먼저 carrier_countries 테이블에서 zoneIndex 조회
        조회된 zoneIndex를 사용하여 carrier_rate_charges에서 요금 조회
    - Type-safe한 쿼리 작성
    - null 체크 및 예외 처리 포함
  3. ShipmentService 수정:
    - CarrierRateChargeRepository 주입
    - QueryDSL 메서드 호출로 변경
   
  QueryDSL의 장점:
  - Type-safe한 쿼리 작성
  - 컴파일 시점에 오류 검출
  - IDE의 자동완성 지원
  - 더 읽기 쉽고 유지보수가 용이한 코드

  4. 오탈자 변경
  - AuthIntegrationTest, PartnerIntegrationTest, SellerIntegrationTest, volume_weight

  5. FEDEX 대기시간 변경
  - FedexRestTemplateConfig     
  - private static final int CONNECT_TIMEOUT_MS = 60000;           // 60초
  - private static final int CONNECTION_REQUEST_TIMEOUT_MS = 60000; // 60초

 6. User Auth 관련
   - 인증유저의 id값을 조회하면 UserTable의 id값이 조회됨. Partner id값을 조회를 위해 Partner 테이블에서 user_id를 조회
