### PR TITLE
✏️ [fix] #169 셀러 주문 통계 대시보드 응답 수정

### DIFF
--- a/src/main/java/org/example/oshipserver/domain/order/dto/response/OrderStatsResponse.java
+++ b/src/main/java/org/example/oshipserver/domain/order/dto/response/OrderStatsResponse.java
@@ -4,22 +4,19 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.example.oshipserver.domain.order.entity.enums.OrderStatus;
 
 public record OrderStatsResponse(
     String month,
     int totalOrders,
-    Map<OrderStatus, Long> statusCounts,
+    Map<String, Long> statusCounts,
     BigDecimal totalWeightKg,
-    Amount totalOrderValue,
-    Map<String, Long> dailyOrderCount // redis 역직렬화 문제로 변경 LocalDate → String
+    Map<String, Long> dailyOrderCount
 ) {
     public static OrderStatsResponse from(
         String month,
         int totalOrders,
-        Map<OrderStatus, Long> statusCounts,
+        Map<String, Long> statusCounts,
         BigDecimal totalWeightKg,
-        long totalAmount,
         Map<LocalDate, Long> dailyOrderCount
     ) {
         return new OrderStatsResponse(
@@ -27,8 +24,7 @@ public record OrderStatsResponse(
             totalOrders,
             statusCounts,
             totalWeightKg,
-            new Amount(totalAmount, "KRW"),
-            convertDateMapToStringMap(dailyOrderCount) // 변환 메서드 적용
+            convertDateMapToStringMap(dailyOrderCount)
         );
     }
 
@@ -39,6 +35,4 @@ public record OrderStatsResponse(
                 Map.Entry::getValue
             ));
     }
-
-    public record Amount(long amount, String currency) {}
 }

--- a/src/main/java/org/example/oshipserver/domain/order/service/stats/OrderStatsCalculator.java
+++ b/src/main/java/org/example/oshipserver/domain/order/service/stats/OrderStatsCalculator.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.example.oshipserver.domain.order.dto.response.OrderStatsResponse;
 import org.example.oshipserver.domain.order.entity.Order;
-import org.example.oshipserver.domain.order.entity.enums.OrderStatus;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,53 +18,47 @@ public class OrderStatsCalculator {
             orders.size(),
             getStatusCounts(orders),
             getTotalWeight(orders),
-            getTotalAmount(orders),
             getDailyOrderCount(orders)
         );
     }
 
-
     /**
-     * 주문 상태별 건수를 계산
-     * 예: PENDING 10건, SHIPPED 8건 등
-     *
-     * @param orders 주문 리스트
-     * @return 상태별 주문 수 집계 Map
+     * lastTrackingEvent를 사용자 친화 배송 상태로 매핑 후 카운트
      */
-    private Map<OrderStatus, Long> getStatusCounts(List<Order> orders) {
+    private Map<String, Long> getStatusCounts(List<Order> orders) {
         return orders.stream()
-            .collect(Collectors.groupingBy(Order::getCurrentStatus, Collectors.counting()));
+            .map(order -> mapTrackingEventToShippingStatus(order.getLastTrackingEvent()))
+            .filter(status -> status != null) // null(매핑 불가)은 제외
+            .collect(Collectors.groupingBy(status -> status, Collectors.counting()));
     }
 
     /**
-     * 전체 주문의 실제 중량 합계를 계산
-     * - null 값은 제외
-     *
-     * @param orders 주문 리스트
-     * @return 총 중량 (Kg)
+     * lastTrackingEvent를 사용자 친화 배송 상태로 변환
+     */
+    private String mapTrackingEventToShippingStatus(String event) {
+        if (event == null) return "ETC";
+
+        return switch (event) {
+            case "ORDER_PLACED" -> "PREPARING";
+            case "LABEL_CREATED" -> "READY";
+            case "AWB_CREATED", "CENTER_ARRIVED", "PICKUP_DELAY", "READY_SHIP", "SHIPPED",
+                 "DEST_COUNTRY_ARRIVED", "CLEARANCE_DELAY", "IN_CLEARANCE", "CLEARED",
+                 "FINAL_DEST_TRANSIT", "FINAL_DEST_ARRIVED", "IN_TRANSIT", "HUB_ARRIVED",
+                 "DELIVERY_DELAY", "DELIVERY_EXCEPTION", "IN_DELIVERY" -> "SHIPPING";
+            case "DELIVERED" -> "DELIVERED";
+            case "RETURN" -> "RETURNING";
+            default -> "ETC";
+        };
+    }
+
+    /**
+     * 전체 주문의 실제 중량 합계
      */
     private BigDecimal getTotalWeight(List<Order> orders) {
         return orders.stream()
             .map(Order::getShipmentActualWeight)
             .filter(weight -> weight != null)
             .reduce(BigDecimal.ZERO, BigDecimal::add);
-    }
-
-    /**
-     * 전체 주문의 총 금액을 계산
-     * - 각 주문의 아이템별 (단가 × 수량)을 합산
-     * - 금액 단위는 KRW 기준이라고 가정
-     *
-     * @param orders 주문 리스트
-     * @return 총 금액 (long, 단위: KRW)
-     */
-    private long getTotalAmount(List<Order> orders) {
-        return orders.stream()
-            .flatMap(order -> order.getOrderItems().stream())  // 모든 주문의 아이템 평탄화 -> 여기서 N+1 발생
-            .map(item -> item.getUnitValue()  // 단가
-                .multiply(BigDecimal.valueOf(item.getQuantity()))) // 단가 × 수량
-            .reduce(BigDecimal.ZERO, BigDecimal::add) // 합산
-            .longValue(); // 최종 long 변환 (소수점 버림)
     }
 
     /**


### PR DESCRIPTION
## ✏️ Issue

Closes #169 


## ☑️ Todo

- [ ]  주문 통계 집계 기준을 `OrderStatus` → `lastTrackingEvent` 기반 배송 상태로 변경
- [ ]  배송 상태 매핑 로직 추가 (`PREPARING`, `READY`, `SHIPPING`, `DELIVERED`, `RETURNING`, `ETC`)
- [ ]  `totalOrderValue` 필드 제거
- [ ]  응답 DTO 구조 변경 (배송 상태 기반 `statusCounts`, 금액 필드 제거)


## ✅ Test Result
![image](https://github.com/user-attachments/assets/109745cb-aa8d-4fb5-ac94-21195912a4df)



## 💌 Reviewer Notes

- 내부적으로 `OrderStatus`가 아닌 `lastTrackingEvent` 기반으로 변경했습니다.