### PR TITLE
♻️ [refactor] 결제파트 외부api에러 분기처리 및 해당 테스트코드 추가

### DIFF
--- a/src/main/java/org/example/oshipserver/client/toss/IdempotentRestClient.java
+++ b/src/main/java/org/example/oshipserver/client/toss/IdempotentRestClient.java
@@ -44,6 +44,13 @@ public class IdempotentRestClient { // 토스의 post 요청을 멱등성 방식
     @Value("${toss.secret-key}")
     private String tossSecretKey;
 
+    // ✅ 테스트용 강제 실패 플래그 추가
+    private boolean forceFail = false;
+
+    public void setForceFail(boolean forceFail) {
+        this.forceFail = forceFail;
+    }
+
     /**
      * 멱등성 post 요청 처리 메서드
      *

--- a/src/main/java/org/example/oshipserver/client/toss/TossApiResponseErrorHandler.java
+++ b/src/main/java/org/example/oshipserver/client/toss/TossApiResponseErrorHandler.java
@@ -1,0 +1,53 @@
+package org.example.oshipserver.client.toss;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.oshipserver.global.exception.ApiException;
+import org.example.oshipserver.global.exception.ErrorType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.ResponseErrorHandler;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TossApiResponseErrorHandler implements ResponseErrorHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean hasError(ClientHttpResponse response) throws IOException {
+        // 4xx or 5xx는 모두 error로 간주
+        return response.getStatusCode().is4xxClientError() || response.getStatusCode().is5xxServerError();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void handleError(ClientHttpResponse response) throws IOException {
+        String responseBody = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+        HttpStatusCode statusCode = response.getStatusCode();
+
+        log.error("[Toss ErrorHandler] statusCode: {}, body: {}", statusCode, responseBody);
+
+        String errorCode = null;
+        try {
+            Map<String, String> parsed = objectMapper.readValue(responseBody, Map.class);
+            errorCode = parsed.get("code");
+        } catch (Exception e) {
+            log.warn("Toss 에러 바디 파싱 실패: {}", e.getMessage());
+        }
+
+        // 4xx 에러는 retry 없이 바로 ApiException
+        if (statusCode.is4xxClientError()) {
+            throw new ApiException("[4xx] " + errorCode + ": 재시도 불필요", ErrorType.TOSS_PAYMENT_FAILED);
+        }
+
+        // 5xx 등은 retry 대상
+        throw new ApiException("[Toss API Error] " + statusCode, ErrorType.TOSS_PAYMENT_FAILED);
+    }
+}

--- a/src/main/java/org/example/oshipserver/client/toss/TossApiResponseErrorHandler.java
+++ b/src/main/java/org/example/oshipserver/client/toss/TossApiResponseErrorHandler.java
@@ -22,18 +22,21 @@ public class TossApiResponseErrorHandler implements ResponseErrorHandler {
 
     @Override
     public boolean hasError(ClientHttpResponse response) throws IOException {
-        // 4xx or 5xx는 모두 error로 간주
+        // Toss API 응답이 4xx 또는 5xx일 경우 에러로 판단
         return response.getStatusCode().is4xxClientError() || response.getStatusCode().is5xxServerError();
     }
 
     @SuppressWarnings("deprecation")
     @Override
     public void handleError(ClientHttpResponse response) throws IOException {
+        // 위 hasError()가 true를 반환한 경우 실행됨
+        // Toss API 응답 바디를 문자열로 읽어옴
         String responseBody = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
         HttpStatusCode statusCode = response.getStatusCode();
 
         log.error("[Toss ErrorHandler] statusCode: {}, body: {}", statusCode, responseBody);
 
+        // Toss에서 제공하는 에러 코드 추출
         String errorCode = null;
         try {
             Map<String, String> parsed = objectMapper.readValue(responseBody, Map.class);
@@ -42,12 +45,13 @@ public class TossApiResponseErrorHandler implements ResponseErrorHandler {
             log.warn("Toss 에러 바디 파싱 실패: {}", e.getMessage());
         }
 
-        // 4xx 에러는 retry 없이 바로 ApiException
+        // 예외 분기처리
         if (statusCode.is4xxClientError()) {
+            // 4xx: 고객 귀책 에러(재시도하면 안 됨) → ApiException 발생시켜 retry 방지
             throw new ApiException("[4xx] " + errorCode + ": 재시도 불필요", ErrorType.TOSS_PAYMENT_FAILED);
         }
 
-        // 5xx 등은 retry 대상
+        // 5xx: Toss 서버 문제(재시도 대상) → ApiException 발생시켜 @Retryable 작동 유도
         throw new ApiException("[Toss API Error] " + statusCode, ErrorType.TOSS_PAYMENT_FAILED);
     }
 }

--- a/src/main/java/org/example/oshipserver/client/toss/TossRestTemplateConfig.java
+++ b/src/main/java/org/example/oshipserver/client/toss/TossRestTemplateConfig.java
@@ -1,5 +1,7 @@
 package org.example.oshipserver.client.toss;
 
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -11,9 +13,15 @@ import java.util.List;
 public class TossRestTemplateConfig {
 
     @Bean
-    public RestTemplate tossRestTemplate() {
+    public RestTemplate tossRestTemplate(ObjectMapper objectMapper) {
         RestTemplate restTemplate = new RestTemplate();
+
+        // json 메시지 컨버터 설정
         restTemplate.setMessageConverters(List.of(new MappingJackson2HttpMessageConverter()));
+
+        // Toss API 에러 핸들러 설정
+        restTemplate.setErrorHandler(new TossApiResponseErrorHandler(objectMapper));
+
         return restTemplate;
     }
 }

--- a/src/main/java/org/example/oshipserver/global/config/RetryConfig.java
+++ b/src/main/java/org/example/oshipserver/global/config/RetryConfig.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.annotation.EnableRetry;
 
 @Configuration
-@EnableRetry
+@EnableRetry 
 public class RetryConfig {
 
 }

--- a/src/test/java/org/example/oshipserver/client/toss/TossApiResponseErrorHandlerTest.java
+++ b/src/test/java/org/example/oshipserver/client/toss/TossApiResponseErrorHandlerTest.java
@@ -1,0 +1,116 @@
+package org.example.oshipserver.client.toss;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.oshipserver.global.exception.ApiException;
+import org.example.oshipserver.global.exception.ErrorType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class TossApiResponseErrorHandlerTest {
+
+    private TossApiResponseErrorHandler errorHandler;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        errorHandler = new TossApiResponseErrorHandler(objectMapper);
+    }
+
+    @Test
+    @DisplayName("4xx 응답이면 ApiException 발생 및 retry 대상이 아니다")
+    void handleError_4xx_shouldThrowApiException_NoRetry() throws IOException {
+        // given : Toss api가 400에러 응답 반환
+        String body = """
+            {
+              "code": "ALREADY_PROCESSED_PAYMENT",
+              "message": "이미 처리된 결제입니다."
+            }
+            """;
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        when(response.getStatusCode()).thenReturn(HttpStatusCode.valueOf(400));
+        when(response.getBody()).thenReturn(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+
+        // when & then: handleError()가 ApiException을 던지며, 메시지에 "4xx", "재시도 불필요"가 포함되는지 확인
+        assertThatThrownBy(() -> errorHandler.handleError(response))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining("4xx")
+            .hasMessageContaining("재시도 불필요");
+    }
+
+    @Test
+    @DisplayName("5xx 응답이면 ApiException 발생 및 retry 대상이다")
+    void handleError_5xx_shouldThrowApiException_Retryable() throws IOException {
+        // given : Toss api가 500에러 응답 반환
+        String body = """
+            {
+              "code": "INTERNAL_ERROR",
+              "message": "서버 오류입니다."
+            }
+            """;
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        when(response.getStatusCode()).thenReturn(HttpStatusCode.valueOf(500));
+        when(response.getBody()).thenReturn(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+
+        // when & then : handleError()가 ApiException을 던지며, 메시지에 "Toss API Error"가 포함되는지 확인
+        assertThatThrownBy(() -> errorHandler.handleError(response))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining("Toss API Error");
+    }
+
+    @Test
+    @DisplayName("hasError(): 4xx 응답이면 true 반환")
+    void hasError_shouldReturnTrue_when4xx() throws IOException {
+         // given : Toss api가 400에러 응답을 반환
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        when(response.getStatusCode()).thenReturn(HttpStatusCode.valueOf(400));
+
+        // when : hasError() 호출
+        boolean result = errorHandler.hasError(response);
+
+        // then : 에러로 판단하여 true 반환
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("hasError(): 5xx 응답이면 true 반환")
+    void hasError_shouldReturnTrue_when5xx() throws IOException {
+        // given : Toss api가 500에러 응답을 반환
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        when(response.getStatusCode()).thenReturn(HttpStatusCode.valueOf(500));
+
+        // when : hasError() 호출
+        boolean result = errorHandler.hasError(response);
+
+        // then : 에러로 판단하여 true 반환
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("hasError(): 2xx 응답이면 false 반환")
+    void hasError_shouldReturnFalse_when2xx() throws IOException {
+        // given : Toss api가 정상적인 200 응답을 반환
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        when(response.getStatusCode()).thenReturn(HttpStatusCode.valueOf(200));
+
+        // when : hasError() 호출
+        boolean result = errorHandler.hasError(response);
+
+        // then : 정상응답으로 판단하여 false 반환
+        assertFalse(result);
+    }
+
+}

--- a/src/test/java/org/example/oshipserver/client/toss/TossApiResponseErrorHandlerTest.java
+++ b/src/test/java/org/example/oshipserver/client/toss/TossApiResponseErrorHandlerTest.java
@@ -113,4 +113,20 @@ class TossApiResponseErrorHandlerTest {
         assertFalse(result);
     }
 
+    @Test
+    @DisplayName("응답 바디가 JSON이 아닌 경우에도 ApiException 발생")
+    void handleError_shouldHandleMalformedJsonGracefully() throws IOException {
+        // given: Toss API에서 비정상적인 응답 포맷을 반환한 상황
+        String malformedBody = "Not a JSON";
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        when(response.getStatusCode()).thenReturn(HttpStatusCode.valueOf(500));
+        when(response.getBody()).thenReturn(new ByteArrayInputStream(malformedBody.getBytes(StandardCharsets.UTF_8)));
+
+        // when & then: errorHandler가 예외를 던지는지 확인
+        assertThatThrownBy(() -> errorHandler.handleError(response))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining("Toss API Error");
+    }
+
+
 }


### PR DESCRIPTION
## ✏️ Issue
Closes #165

## ☑️ Todo
- Toss API에 대한 커스텀 에러 핸들러 생성 (TossApiResponseErrorHandler) 및 RestTemplate에 등록
- 에러타입 분기처리 : Toss API의 4xx / 5xx 응답을 분석해 ApiException으로 포장하여 던지도록

- 예외 상황에 대한 테스트 코드 추가
## ✅ Test Result
- 문제상황 인식 : 400에러일때도 retry 작동 >> 외부api에러 분기처리 필요
![400에러일때 retry작동(문제인식)](https://github.com/user-attachments/assets/f64bf655-d6ef-4437-a17e-0db428ba27d0)

- retry 로직 정상작동 단위테스트
![retry로직 단위테스트 통과](https://github.com/user-attachments/assets/83e8cbb0-fc2e-4838-90ba-90ee2d9fe4ef)

- 에러 분기처리 단위테스트
![에러 분기처리 단위테스트 통과](https://github.com/user-attachments/assets/a0f2a827-fd82-4c10-92bb-ef4e7ddacde5)


## 💌 Reviewer Notes
