### PR TITLE
✨ [feat] 결제 상태 변경에 따른 이메일 전송 로직 구현

### DIFF
--- a/src/main/java/org/example/oshipserver/domain/notification/entity/NotificationType.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/entity/NotificationType.java
@@ -4,7 +4,7 @@ public enum NotificationType {
     ORDER_CREATED,     // 주문 생성 완료
     ORDER_CANCELLED,   // 주문 취소
     PAYMENT_COMPLETED, // 결제 완료
-    PAYMENT_CANCELLED,    // 결제 취소
+    PAYMENT_CANCELLED, // 결제 취소
     DELIVERY_STARTED,  // 배송 시작
     DELIVERY_COMPLETED // 배송 완료
 }

--- a/src/main/java/org/example/oshipserver/domain/notification/entity/NotificationType.java
+++ b/src/main/java/org/example/oshipserver/domain/notification/entity/NotificationType.java
@@ -4,7 +4,7 @@ public enum NotificationType {
     ORDER_CREATED,     // 주문 생성 완료
     ORDER_CANCELLED,   // 주문 취소
     PAYMENT_COMPLETED, // 결제 완료
-    PAYMENT_FAILED,    // 결제 실패
+    PAYMENT_CANCELLED,    // 결제 취소
     DELIVERY_STARTED,  // 배송 시작
     DELIVERY_COMPLETED // 배송 완료
 }

--- a/src/main/java/org/example/oshipserver/domain/payment/service/PaymentNotificationService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/PaymentNotificationService.java
@@ -1,0 +1,73 @@
+package org.example.oshipserver.domain.payment.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.oshipserver.domain.notification.dto.request.NotificationRequest;
+import org.example.oshipserver.domain.notification.entity.NotificationType;
+import org.example.oshipserver.domain.notification.service.EmailNotificationService;
+import org.example.oshipserver.domain.payment.entity.Payment;
+import org.example.oshipserver.domain.payment.entity.PaymentOrder;
+import org.example.oshipserver.domain.order.entity.Order;
+import org.example.oshipserver.domain.seller.entity.Seller;
+import org.example.oshipserver.domain.seller.repository.SellerRepository;
+import org.example.oshipserver.domain.user.entity.User;
+import org.example.oshipserver.domain.user.repository.UserRepository;
+import org.example.oshipserver.global.exception.ApiException;
+import org.example.oshipserver.global.exception.ErrorType;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentNotificationService {
+
+    private final UserRepository userRepository;
+    private final EmailNotificationService emailNotificationService;
+    private final SellerRepository sellerRepository;
+
+    /**
+     * 결제 완료 알림
+     */
+    public void sendPaymentCompletedV2(Payment payment) {
+        Seller seller = sellerRepository.findById(payment.getSellerId())
+            .orElseThrow(() -> new ApiException("셀러 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
+
+        User user = userRepository.findById(seller.getUserId())
+            .orElseThrow(() -> new ApiException("유저 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
+
+
+        NotificationRequest request = new NotificationRequest(
+            NotificationType.PAYMENT_COMPLETED,
+            "[OSH] 결제 완료 알림",
+            "결제가 정상적으로 완료되었습니다.\n" +
+                "결제번호: " + payment.getPaymentKey() + "\n" +
+                "결제금액: " + payment.getAmount() + "원",
+            user.getEmail()
+        );
+
+        emailNotificationService.send(request);
+    }
+
+    /**
+     * 결제 취소 알림
+     */
+    public void sendPaymentCancelledV2(Payment payment) {
+        Seller seller = sellerRepository.findById(payment.getSellerId())
+            .orElseThrow(() -> new ApiException("셀러 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
+
+        User user = userRepository.findById(seller.getUserId())
+            .orElseThrow(() -> new ApiException("유저 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
+
+        NotificationRequest request = new NotificationRequest(
+            NotificationType.PAYMENT_CANCELLED,
+            "[OSH] 결제 취소 알림",
+            "결제가 취소되었습니다.\n" +
+                "결제번호: " + payment.getPaymentKey() + "\n" +
+                "환불금액: " + payment.getAmount() + "원",
+            user.getEmail()
+        );
+
+        emailNotificationService.send(request);
+    }
+
+}

--- a/src/main/java/org/example/oshipserver/domain/payment/service/PaymentNotificationService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/PaymentNotificationService.java
@@ -40,7 +40,7 @@ public class PaymentNotificationService {
             NotificationType.PAYMENT_COMPLETED,
             "[OSH] 결제 완료 알림",
             "결제가 정상적으로 완료되었습니다.\n" +
-                "결제번호: " + payment.getPaymentKey() + "\n" +
+                "결제번호: " + payment.getPaymentNo() + "\n" +
                 "결제금액: " + payment.getAmount() + "원",
             user.getEmail()
         );

--- a/src/main/java/org/example/oshipserver/domain/payment/service/PaymentNotificationService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/PaymentNotificationService.java
@@ -29,12 +29,18 @@ public class PaymentNotificationService {
      * 결제 완료 알림
      */
     public void sendPaymentCompletedV2(Payment payment) {
-        Seller seller = sellerRepository.findById(payment.getSellerId())
-            .orElseThrow(() -> new ApiException("셀러 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
+        // sellerId와 userId 연관관계 다시 정리되고 나면 아래 코드로 살릴 것
+//        Seller seller = sellerRepository.findById(payment.getSellerId())
+//            .orElseThrow(() -> new ApiException("셀러 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
+//        User user = userRepository.findById(seller.getUserId())
+//            .orElseThrow(() -> new ApiException("유저 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
 
+        // sellerId와 userId 연관관계 수정 전, 임시 코드
+        // sellerId는 사실상 userId임
+        Seller seller = sellerRepository.findByUserId(payment.getSellerId())
+            .orElseThrow(() -> new ApiException("셀러 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
         User user = userRepository.findById(seller.getUserId())
             .orElseThrow(() -> new ApiException("유저 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
-
 
         NotificationRequest request = new NotificationRequest(
             NotificationType.PAYMENT_COMPLETED,
@@ -52,9 +58,16 @@ public class PaymentNotificationService {
      * 결제 취소 알림
      */
     public void sendPaymentCancelledV2(Payment payment) {
-        Seller seller = sellerRepository.findById(payment.getSellerId())
-            .orElseThrow(() -> new ApiException("셀러 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
+        // sellerId와 userId 연관관계 다시 정리되고 나면 아래 코드로 살릴 것
+//        Seller seller = sellerRepository.findById(payment.getSellerId())
+//            .orElseThrow(() -> new ApiException("셀러 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
+//        User user = userRepository.findById(seller.getUserId())
+//            .orElseThrow(() -> new ApiException("유저 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
 
+        // sellerId와 userId 연관관계 수정 전, 임시 코드
+        // sellerId는 사실상 userId임
+        Seller seller = sellerRepository.findByUserId(payment.getSellerId())
+            .orElseThrow(() -> new ApiException("셀러 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
         User user = userRepository.findById(seller.getUserId())
             .orElseThrow(() -> new ApiException("유저 정보를 찾을 수 없습니다.", ErrorType.NOT_FOUND));
 

--- a/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/example/oshipserver/domain/payment/service/PaymentService.java
@@ -387,21 +387,20 @@ public class PaymentService {
             throw new ApiException("부분취소 금액이 유효하지 않습니다.", ErrorType.PAYMENT_INVALID_CANCEL_AMOUNT);
         }
 
-        // 7. PaymentOrder 상태만 CANCEL 처리 (ORDER는 상태변화 없음)
+        // 7. PaymentOrder 상태만 CANCEL 처리
         paymentOrder.cancel();  // paymentStatus : CANCEL
         paymentOrderRepository.save(paymentOrder);
 
-//        Order order = paymentOrder.getOrder();
-//        try {
-//            order.markAs(OrderStatus.CANCELLED);
-//            log.info("주문 상태가 CANCELLED로 변경되었습니다. orderId={}", order.getId());
-//        } catch (IllegalStateException exxx) {
-//            log.warn("주문 상태를 CANCELLED로 변경하지 못했습니다. orderId={}, currentStatus={}, reason={}",
-//                order.getId(), order.getCurrentStatus(), exxx.getMessage());
-//        }
-//
-//        paymentOrderRepository.save(paymentOrder);
-//        orderRepository.save(order);
+        // 취소된 order의 상태만 PARTIAL_CANCEL로 변경
+        Order order = paymentOrder.getOrder();
+        try {
+            order.markAs(OrderStatus.CANCELLED);
+            log.info("주문 상태가 CANCELLED로 변경되었습니다. orderId={}", order.getId());
+            orderRepository.save(order);
+        } catch (IllegalStateException ex) {
+            log.warn("주문 상태를 CANCELLED로 변경하지 못했습니다. orderId={}, currentStatus={}, reason={}",
+                order.getId(), order.getCurrentStatus(), ex.getMessage());
+        }
 
         // 8. 취소 이력 저장
         PaymentCancelHistory history = PaymentCancelHistory.create(paymentOrder, cancelAmount, cancelReason);
@@ -426,14 +425,14 @@ public class PaymentService {
 
             // 모든 주문 상태를 REFUNDED로 변경
             for (PaymentOrder po : payment.getPaymentOrders()) {
-                Order order = po.getOrder();
+                Order o = po.getOrder();
                 try {
-                    order.markAs(OrderStatus.REFUNDED);
+                    o.markAs(OrderStatus.REFUNDED);
                     log.info("주문 상태가 REFUNDED로 변경되었습니다. orderId={}", order.getId());
-                    orderRepository.save(order);
+                    orderRepository.save(o);
                 } catch (IllegalStateException exx) {
                     log.warn("주문 상태 REFUNDED 전이 실패. orderId={}, currentStatus={}, reason={}",
-                        order.getId(), order.getCurrentStatus(), exx.getMessage());
+                        o.getId(), o.getCurrentStatus(), exx.getMessage());
                 }
             }
             // 큐 기반 비동기 이메일 전송 (전체 취소가 완료된 시점에 결제 취소 알림)

--- a/src/main/java/org/example/oshipserver/domain/seller/repository/SellerRepository.java
+++ b/src/main/java/org/example/oshipserver/domain/seller/repository/SellerRepository.java
@@ -1,9 +1,14 @@
 package org.example.oshipserver.domain.seller.repository;
 
+import java.util.Optional;
 import org.example.oshipserver.domain.seller.entity.Seller;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SellerRepository extends JpaRepository<Seller, Long>, ISellerRepository {
 
     boolean existsByCompanyRegisterNo(String companyRegisterNo);
+
+    // sellerId와 userId 연관관계 수정 전, 임시 코드
+    Optional<Seller> findByUserId(Long userId);
+
 }

--- a/src/test/java/org/example/oshipserver/domain/payment/service/PaymentNotificationServiceTest.java
+++ b/src/test/java/org/example/oshipserver/domain/payment/service/PaymentNotificationServiceTest.java
@@ -61,7 +61,7 @@ class PaymentNotificationServiceTest {
     @Test
     @DisplayName("결제 완료 알림 전송 성공")
     void sendPaymentCompletedV2_success() {
-        when(sellerRepository.findById(1L)).thenReturn(Optional.of(seller));
+        when(sellerRepository.findByUserId(1L)).thenReturn(Optional.of(seller));
         when(userRepository.findById(2L)).thenReturn(Optional.of(user));
 
         paymentNotificationService.sendPaymentCompletedV2(payment);
@@ -72,7 +72,7 @@ class PaymentNotificationServiceTest {
     @Test
     @DisplayName("결제 취소 알림 전송 성공")
     void sendPaymentCancelledV2_success() {
-        when(sellerRepository.findById(1L)).thenReturn(Optional.of(seller));
+        when(sellerRepository.findByUserId(1L)).thenReturn(Optional.of(seller));
         when(userRepository.findById(2L)).thenReturn(Optional.of(user));
 
         paymentNotificationService.sendPaymentCancelledV2(payment);

--- a/src/test/java/org/example/oshipserver/domain/payment/service/PaymentNotificationServiceTest.java
+++ b/src/test/java/org/example/oshipserver/domain/payment/service/PaymentNotificationServiceTest.java
@@ -1,0 +1,82 @@
+package org.example.oshipserver.domain.payment.service;
+
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.example.oshipserver.domain.notification.service.EmailNotificationService;
+import org.example.oshipserver.domain.payment.entity.Payment;
+import org.example.oshipserver.domain.seller.entity.Seller;
+import org.example.oshipserver.domain.seller.repository.SellerRepository;
+import org.example.oshipserver.domain.user.entity.User;
+import org.example.oshipserver.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class PaymentNotificationServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SellerRepository sellerRepository;
+
+    @Mock
+    private EmailNotificationService emailNotificationService;
+
+    @InjectMocks
+    private PaymentNotificationService paymentNotificationService;
+
+    private Payment payment;
+    private Seller seller;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        // 기본 mock 객체 생성
+        seller = Seller.builder()
+            .id(1L)
+            .userId(2L)
+            .build();
+
+        user = User.builder()
+            .id(2L)
+            .email("test@example.com")
+            .build();
+
+        payment = Payment.builder()
+            .paymentKey("test-payment-key")
+            .amount(10000)
+            .sellerId(1L)
+            .build();
+    }
+
+    @Test
+    @DisplayName("결제 완료 알림 전송 성공")
+    void sendPaymentCompletedV2_success() {
+        when(sellerRepository.findById(1L)).thenReturn(Optional.of(seller));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
+
+        paymentNotificationService.sendPaymentCompletedV2(payment);
+
+        verify(emailNotificationService, times(1)).send(any());
+    }
+
+    @Test
+    @DisplayName("결제 취소 알림 전송 성공")
+    void sendPaymentCancelledV2_success() {
+        when(sellerRepository.findById(1L)).thenReturn(Optional.of(seller));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
+
+        paymentNotificationService.sendPaymentCancelledV2(payment);
+
+        verify(emailNotificationService, times(1)).send(any());
+    }
+}


### PR DESCRIPTION
## ✏️ Issue
Closes #182

## ☑️ Todo
결제 파트도 이메일 로직 연결했습니다
(결제 성공, 전체취소 일때만 이메일 전송됩니다)

추가) sellerId와 userId 연관관계 수정 전 코드에 맞춰서, 발생하는 에러 해결했습니다. 기존코드는 주석처리.

그리고 지금 토스 결제 api 잘 굴러가용ㅇ

## ✅ Test Result
- 결제 상태 변경에 따른 알림 전송 성공
![결제 알림 메일 전송 성공](https://github.com/user-attachments/assets/0564cb18-b627-47ae-b16e-e266ea9ad56f)

- 알림 로직 결제테스트 진행 및 성공
![결제상태변화에 따른 이메일 알림 전송](https://github.com/user-attachments/assets/cd5efba2-893f-477a-a7b8-394ea8ad814c)

- sellerId와 userId 연관관계 수정 전 코드일때 기존 에러 (해결)
![알림 로직 에러](https://github.com/user-attachments/assets/9232e3ab-b43a-49be-9b27-874e3f5c40a3)


## 💌 Reviewer Notes
